### PR TITLE
Add landing page blueprint and enable route smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Framework Owner checkpoint for the PocketSage desktop-first Flask app. Focus are
 2. `pip install -e ".[dev]"`
 3. `cp .env.example .env`
 4. `python run.py`
-5. Visit http://127.0.0.1:5000 (blueprints return scaffolded templates)
+5. Visit http://127.0.0.1:5000 to view the landing page and navigate to scaffolded blueprints
 
 ### Make Targets
 - `make setup` → install deps, enable pre-commit

--- a/pocketsage/__init__.py
+++ b/pocketsage/__init__.py
@@ -27,6 +27,7 @@ def _resolve_config(name: str | None) -> type[BaseConfig]:
 def _blueprint_paths() -> Iterable[str]:
     """Yield blueprint import paths registered by the framework owner."""
 
+    yield "pocketsage.blueprints.home"
     yield "pocketsage.blueprints.ledger"
     yield "pocketsage.blueprints.habits"
     yield "pocketsage.blueprints.liabilities"

--- a/pocketsage/blueprints/home/__init__.py
+++ b/pocketsage/blueprints/home/__init__.py
@@ -1,0 +1,15 @@
+"""Home blueprint package."""
+
+from __future__ import annotations
+
+from flask import Blueprint
+
+bp = Blueprint(
+    "home",
+    __name__,
+    template_folder="../../templates/home",
+)
+
+from . import routes  # noqa: E402,F401 - ensure routes register
+
+__all__ = ["bp"]

--- a/pocketsage/blueprints/home/routes.py
+++ b/pocketsage/blueprints/home/routes.py
@@ -1,0 +1,14 @@
+"""Home routes."""
+
+from __future__ import annotations
+
+from flask import render_template
+
+from . import bp
+
+
+@bp.get("/")
+def landing_page():
+    """Render the PocketSage landing page."""
+
+    return render_template("home/index.html")

--- a/pocketsage/templates/home/index.html
+++ b/pocketsage/templates/home/index.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}PocketSage · Home{% endblock %}
+
+{% block content %}
+  <section class="landing">
+    <h1>Welcome to PocketSage</h1>
+    <p>Your offline hub for budgeting, habit tracking, liabilities, and portfolio insights.</p>
+    <p><a href="{{ url_for('ledger.list_transactions') }}" class="button">View Ledger</a></p>
+  </section>
+{% endblock %}

--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -17,6 +17,7 @@ def client():
 @pytest.mark.parametrize(
     "path",
     [
+        "/",
         "/ledger/",
         "/ledger/new",
         "/habits/",
@@ -28,7 +29,6 @@ def client():
         "/admin/",
     ],
 )
-@pytest.mark.skip(reason="TODO(@qa-team): unskip once templates render with real data.")
 def test_routes_render(path, client):
     response = client.get(path)
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add a home blueprint that renders a simple landing page and register it with the app factory
- introduce a landing page template with navigation back to the ledger and refresh the quickstart docs
- expand the route smoke test matrix to cover the root URL and enable the test

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68f814ee26948321b95b8fe093918e66