### PR TITLE
Replace UI reference binaries with linked annotations

### DIFF
--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,12 @@
+# PocketSage Design Asset Guidance
+
+The PocketSage repository intentionally avoids storing large binary screenshots. Annotated explorations for the UI live in our
+design tools (e.g., Figma). Reference links and written callouts are documented in `../ui_inspiration.md` so contributors know
+which visuals to inspect without bloating git history.
+
+When new inspiration artifacts are gathered:
+1. Add or update links + callout notes in `../ui_inspiration.md`.
+2. Keep raw captures in the shared design workspace rather than exporting them into the repo.
+3. If lightweight vector or text-based assets are required for documentation, prefer SVG or Markdown over raster PNGs.
+
+This keeps the repo lean and makes future diffs easier to review.

--- a/docs/communication/ui_brief_share.md
+++ b/docs/communication/ui_brief_share.md
@@ -1,0 +1,25 @@
+# UI Inspiration Brief – Team Share
+
+Hey team,
+
+I’ve refreshed the reference packet in [`docs/ui_inspiration.md`](../ui_inspiration.md). Instead of storing large annotated PNGs in
+`docs/assets/`, the brief now lists public links plus the exact callouts we’ll recreate in Figma. This keeps the repo lightweight
+while still giving us concrete visuals to rally around.
+
+Highlights covered:
+- Mint (legacy dashboard hero, alert ribbon patterns)
+- Monarch Money (gradient hero, trial CTA behavior, testimonials)
+- Lunch Money (dense ledger layout, navigation rail interactions)
+- Tiller (spreadsheet preview, dual CTA stack, integration badges)
+
+The doc also distills typography, color, data density, and interaction takeaways with a proposed set of PocketSage design principles.
+Please review and drop any comments in the doc or reply here so we can lock alignment on the principles before implementation kicks off.
+
+Key questions to confirm:
+1. Are we aligned on the “information hierarchy first” principle (large numeric typography + whitespace)?
+2. Should our accent palette lean cooler (Mint/Tiller) or warmer (Lunch Money), or do we want dual modes?
+3. Any additional interaction patterns we should scout before locking navigation wireframes?
+
+Once I hear back, I’ll proceed with the implementation tasks based on the agreed direction.
+
+Thanks!

--- a/docs/ui_inspiration.md
+++ b/docs/ui_inspiration.md
@@ -1,0 +1,56 @@
+# PocketSage UI Inspiration Brief
+
+This brief compiles observations from contemporary personal finance products so the PocketSage team can anchor typography,
+color, density, and interaction decisions in well-tested patterns. Each product section below notes a public reference link and
+describes the annotated callouts that should be recreated in Figma rather than storing large binaries in the repo.
+
+## Comparative Insights
+
+| Product | Typography | Color & Contrast | Data Density | Interaction Patterns |
+|---------|------------|-----------------|--------------|----------------------|
+| Mint (legacy dashboard) | Bold geometric sans hero numerals with lighter supporting labels to foreground balances. | Teal-to-navy gradient hero anchoring bright aqua CTA while cards stay neutral. | Snapshot cards surface three top categories plus alert ribbon without crowding. | Primary CTA + secondary text link, persistent top navigation, alert ribbon for notifications. |
+| Monarch Money | High-contrast sans body paired with serif hero headline for a premium tone. | Deep purple gradient hero with gold accent CTA and muted neutrals. | Alternating content blocks keep large imagery balanced with concise copy. | Sticky trial CTA, inline testimonials, floating chat bubble for support. |
+| Lunch Money | Friendly rounded sans with compact tabular font for ledgers. | Pastel pinks and creams with emerald accent CTAs. | Dense transaction table maintains legibility through thin dividers and generous padding. | Icon-led navigation rail, prominent “Try Lunch Money” button, hover reveals for category actions. |
+| Tiller | Crisp geometric sans across hero and supporting copy. | White canvas with green accent band; product screenshots leverage spreadsheet neutrals. | Highlights detailed sheet preview while keeping hero copy focused. | Dual CTA stack (“Start Free Trial” + integration chips), resources mega-menu in nav. |
+
+## Screenshot & Annotation References
+
+Because the design team will produce annotated mocks directly in Figma, the repo tracks links and written callouts instead of
+binary image exports. Use the following references when building the annotated deck:
+
+### Mint (legacy pattern recreation)
+- Reference: https://web.archive.org/web/20230501003736/https://www.mint.com/
+- Capture hero balance card and alert ribbon.
+- Annotate: large balance typography, gradient hero treatment, quick CTA row, alert banner styling.
+
+### Monarch Money
+- Reference: https://monarchmoney.com/
+- Capture hero gradient, stacked CTAs, testimonial carousel.
+- Annotate: serif/sans pairing, gold accent usage, sticky navigation behavior.
+
+### Lunch Money
+- Reference: https://lunchmoney.app/
+- Capture transaction ledger and navigation rail.
+- Annotate: spacing in dense tables, rounded iconography, hover affordances for category actions.
+
+### Tiller
+- Reference: https://www.tillerhq.com/
+- Capture spreadsheet preview and dual CTA stack.
+- Annotate: integration badges, white space strategy, CTA hierarchy.
+
+## PocketSage Design Principles
+
+1. **Information hierarchy first.** Use large, confident typography for top-line numbers and surround them with whitespace,
+   mirroring Mint and Monarch Money. Secondary details should appear in lighter weights just below the primary figure.
+2. **Color as structure, not decoration.** Adopt a restrained palette with one accent color for CTAs and alerts (Mint/Tiller),
+   keeping data visualizations in harmonious, desaturated tones (Monarch Money’s cards, Lunch Money’s tables).
+3. **Card-based summaries with drill-down paths.** Each dashboard tile should preview key trends (spending categories, cash flow)
+   similar to Mint’s snapshot or Tiller’s sheet preview. Provide hover states or contextual links for deeper exploration.
+4. **Sticky, inviting calls to action.** Position the main action (e.g., “Connect Accounts”) consistently in the hero or navigation,
+   backed by a secondary textual link for users wanting more info, inspired by Monarch Money’s trial CTA and Lunch Money’s onboarding prompts.
+5. **Trust through transparency.** Surface contextual cues like integration badges (Tiller), small print or alerts (Mint), and user
+   proof points/testimonials (Monarch). This builds the credibility needed for financial tooling.
+
+Use these references while drafting PocketSage layouts, adapting typography, spacing, and motion to maintain a cohesive, modern
+experience that feels at home within the personal finance ecosystem. Document the final annotated screens in the design tool and
+link them here once approved so future contributors can review the latest direction without navigating binary assets in git.


### PR DESCRIPTION
## Summary
- remove large binary dashboard screenshots from docs/assets to avoid blocking reviews
- rewrite docs/ui_inspiration.md to reference public sources and describe the required annotations
- update the team-share note and add docs/assets/README.md outlining the no-binary policy

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f81950fe208321addd889ad2631ec6