### PR TITLE
Add runbook guidance for optional extras

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,13 @@
+# PocketSage Runbook
+
+## Installation Extras
+
+PocketSage defines two optional extras in `pyproject.toml` that tailor the development experience:
+
+### Development toolchain (`dev` extra)
+- **Install:** `pip install -e ".[dev]"`
+- **When to use:** Install this extra for day-to-day development. It includes the formatting, linting, and testing tools (`black`, `ruff`, `pytest`, and `pre-commit`) required to work on the codebase and run CI-equivalent checks locally.
+
+### Background file watcher (`watcher` extra)
+- **Install:** `pip install -e ".[watcher]"`
+- **When to use:** Install this extra when you need filesystem event monitoring for background import/testing workflows. It provides the `watchdog` dependency that powers optional observer integrations referenced in the README TODO items.


### PR DESCRIPTION
## Summary
- confirm the `dev` and `watcher` extras defined in `pyproject.toml`
- add a runbook entry that documents how and when to install each optional extra

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f862b01278832180f7015da73ebf4b