### PR TITLE
Highlight watcher extra setup in runbook

### DIFF
--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -3,7 +3,9 @@
 ## Preconditions
 - Python 3.11 installed
 - `pip install -e ".[dev]"`
-- Optional: install `watchdog` extra for auto-import demo (`pip install -e ".[watcher]"`).
+
+### Optional Tooling
+- **Watcher extra** – install with `pip install -e ".[watcher]"` to enable filesystem observers that support future watchdog-based background import workflows outlined in the README.
 
 ## Suggested Narrative
 1. **App Launch**


### PR DESCRIPTION
## Summary
- add an explicit Optional Tooling section to the demo runbook
- document installing the watcher extra and how it supports future watchdog background imports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f862b39c388321b05ccae4ba4dc9f7