### PR TITLE
Document data directory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,13 @@ Framework Owner checkpoint for the PocketSage desktop-first Flask app. Focus are
 
 ## Configuration Flags
 - `.env` values prefixed with `POCKETSAGE_`
+- `POCKETSAGE_DATA_DIR=./instance` ships as the default entry in `.env.example`; leave it in place if you want PocketSage to manage the bundled `instance/` folder out of the box.
 - `POCKETSAGE_USE_SQLCIPHER=true` switches DB URL builder (SQLCipher driver TODO)
 - `POCKETSAGE_DATABASE_URL` overrides computed path if needed
+
+`BaseConfig._resolve_data_dir()` expands the configured data path, creates the directory with `parents=True, exist_ok=True`, and then caches the resolved `Path` during startup. This means the `instance/` folder—and any custom directory you point to—will be created automatically before the database URL is built.【F:pocketsage/config.py†L25-L45】
+
+To store data somewhere else, override `POCKETSAGE_DATA_DIR` in your `.env` file with an absolute or relative path. Ensure the PocketSage process can read from and write to that location (for example, set directory permissions appropriately on Unix with `chmod`/`chown`, or run the app under a user that owns the target folder on Windows) so SQLite/SQLCipher files can be created successfully.【F:pocketsage/config.py†L35-L45】
 
 ## Privacy & Offline Notes
 - All data stored locally under `instance/`


### PR DESCRIPTION
## Summary
- highlight the default POCKETSAGE_DATA_DIR entry in the configuration section of the README
- describe how BaseConfig._resolve_data_dir eagerly creates the data directory on startup
- document how to override the data directory and ensure write permissions for PocketSage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f862b84b188321946366f6d3a8ede5