### PR TITLE
Document data directory resolution in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Framework Owner checkpoint for the PocketSage desktop-first Flask app. Focus are
 - `.env` values prefixed with `POCKETSAGE_`
 - `POCKETSAGE_USE_SQLCIPHER=true` switches DB URL builder (SQLCipher driver TODO)
 - `POCKETSAGE_DATABASE_URL` overrides computed path if needed
+- `_resolve_data_dir` respects `POCKETSAGE_DATA_DIR` and defaults to `instance/`; the directory is created during app factory
+  initialization so the resolved path exists immediately afterwards. Use this location for SQLite files, local backup jobs,
+  or cleanup scripts that prune historical exports.
 
 ## Privacy & Offline Notes
 - All data stored locally under `instance/`


### PR DESCRIPTION
## Summary
- describe how `_resolve_data_dir` sets up the application data directory and when it is created
- note the default `instance/` folder so users can prepare backups or cleanup jobs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f862ba53a48321883272076555f3cf