### PR TITLE
docs: call out secret key requirement for deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# WARNING: Default placeholder; replace with a strong secret before non-local deployments.
 POCKETSAGE_SECRET_KEY=replace-me
 POCKETSAGE_USE_SQLCIPHER=false
 POCKETSAGE_SQLCIPHER_KEY=

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Framework Owner checkpoint for the PocketSage desktop-first Flask app. Focus are
 - `.env` values prefixed with `POCKETSAGE_`
 - `POCKETSAGE_USE_SQLCIPHER=true` switches DB URL builder (SQLCipher driver TODO)
 - `POCKETSAGE_DATABASE_URL` overrides computed path if needed
+- `POCKETSAGE_SECRET_KEY` must be regenerated with a strong random value before any deployment beyond local development (e.g., `python -c "import secrets; print(secrets.token_urlsafe(64))"`).
+
+### Deployment Checklist
+- [ ] Replace the default `replace-me` secret in `.env` so it differs from the fallback defined on `BaseConfig`.
 
 ## Privacy & Offline Notes
 - All data stored locally under `instance/`


### PR DESCRIPTION
## Summary
- warn in `.env.example` that the default secret must be replaced before non-local use
- document generating a strong `POCKETSAGE_SECRET_KEY` and add a deployment checklist item in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f862b907348321b0ff7ff4e6ee3e80