### PR TITLE
Document habits smoke check expectations

### DIFF
--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -5,6 +5,12 @@
 - `pip install -e ".[dev]"`
 - Optional: install `watchdog` extra for auto-import demo (`pip install -e ".[watcher]"`).
 
+## Smoke / Sanity Checklist
+- Launch the dev server (`make dev` or `python run.py`) and load the Habits index at `http://127.0.0.1:5000/habits/`.
+  - Confirm the placeholder copy "TODO(@habits-squad): render habits list with streak badges and toggle buttons." still renders.
+  - If the UI has progressed past the placeholder, record the new behavior in the team log so this checklist and related docs stay accurate.
+- Skim other blueprint index pages to ensure they load without template errors.
+
 ## Suggested Narrative
 1. **App Launch**
    - Run `make dev` (Windows: `python run.py`).

--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -15,20 +15,26 @@ def client():
 
 
 @pytest.mark.parametrize(
-    "path",
+    "path, expected_snippet",
     [
-        "/",
-        "/ledger/",
-        "/ledger/new",
-        "/habits/",
-        "/habits/new",
-        "/liabilities/",
-        "/liabilities/new",
-        "/portfolio/",
-        "/portfolio/upload",
-        "/admin/",
+        ("/", None),
+        ("/ledger/", None),
+        ("/ledger/new", None),
+        (
+            "/habits/",
+            "TODO(@habits-squad): render habits list with streak badges and toggle buttons.",
+        ),
+        ("/habits/new", None),
+        ("/liabilities/", None),
+        ("/liabilities/new", None),
+        ("/portfolio/", None),
+        ("/portfolio/upload", None),
+        ("/admin/", None),
     ],
 )
-def test_routes_render(path, client):
+def test_routes_render(path, expected_snippet, client):
     response = client.get(path)
     assert response.status_code == 200
+    if expected_snippet:
+        body = response.get_data(as_text=True)
+        assert expected_snippet in body


### PR DESCRIPTION
## Summary
- extend the route smoke coverage to assert the habits index still shows the placeholder copy
- add a smoke/sanity checklist to the demo runbook so UI deviations are logged promptly

## Testing
- pytest tests/test_routes_smoke.py *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68f862bc439c8321a4e6c2dee2c5b69a