### PR TITLE
Document liabilities placeholder in QA references

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@
 ## Liabilities & Debts - Vedell Jones
 - [ ] # TODO(@debts-squad) Implement liabilities repository with create/read/update and payoff schedule storage.
 - [ ] # TODO(@debts-squad) Finish snowball and avalanche calculators with deterministic ordering.
-- [ ] # TODO(@debts-squad) Generate payoff timeline chart PNG via `services.reports`.
+- [ ] # TODO(@debts-squad) Generate payoff timeline chart PNG via `services.reports` (UI currently renders a TODO placeholder on `/liabilities/`).
 - [ ] # TODO(@debts-squad) Add ability to record actual payments and reconcile balances.
 - [ ] # TODO(@debts-squad) Surface debt-free date projections in UI.
 

--- a/docs/manual_test_plan.md
+++ b/docs/manual_test_plan.md
@@ -1,0 +1,9 @@
+# PocketSage Manual Test Plan
+
+## Liabilities Blueprint
+- [ ] Visit `/liabilities/` from the running development server.
+  - ✅ Confirm the placeholder paragraph still renders with the `TODO(@debts-squad)` note about payoff strategy visualizations.
+  - 📎 Capture a screenshot if the placeholder is replaced with production-ready content and update QA notes accordingly.
+
+## Notes
+- The liabilities overview currently shows the TODO placeholder in the UI, so no QA note updates are required at this time.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -47,7 +47,7 @@ This roadmap distills the outstanding work in [`TODO.md`](../TODO.md) into a seq
 - Habit repository with streak recalculation and validated form flows.
 - Visualization of weekly/monthly habit completion (heatmaps) and reminder options.
 - Liabilities repository with payoff schedules plus snowball/avalanche calculators.
-- Payoff timeline chart, payment reconciliation, and debt-free date projections in the UI.
+- Payoff timeline chart, payment reconciliation, and debt-free date projections in the UI (current `/liabilities/` view still shows a TODO placeholder).
 
 **Relevant TODO Items**
 - `Habits - Dossell Sinclair` backlog items.


### PR DESCRIPTION
## Summary
- add a manual test plan checklist covering the liabilities route placeholder
- update backlog documentation to note the current TODO placeholder in the liabilities UI

## Testing
- not run (docs-only)

------
https://chatgpt.com/codex/tasks/task_e_68f862bd2ec483219efaee74d5188a89