### PR TITLE
Add QA coverage for admin dashboard attributes

### DIFF
--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -32,3 +32,22 @@ def client():
 def test_routes_render(path, client):
     response = client.get(path)
     assert response.status_code == 200
+
+
+def test_admin_dashboard_includes_required_attributes(client):
+    response = client.get("/admin/")
+    assert response.status_code == 200
+
+    html = response.data.decode("utf-8")
+
+    # stats context renders ledger snapshot values
+    assert "Total Transactions" in html
+    assert "Last Transaction" in html
+
+    # jobs payload and polling endpoint should be exposed via data attributes
+    assert "data-admin-dashboard" in html
+    assert 'data-job-status-endpoint="/admin/jobs/__JOB__"' in html
+    assert "data-initial-jobs='[]'" in html
+
+    # latest_export context should render the empty state when no export exists
+    assert "No exports generated yet." in html


### PR DESCRIPTION
## Summary
- confirm the admin dashboard view exposes stats, latest export metadata, and job payloads in the rendered template
- extend the smoke tests to assert the dashboard HTML includes the expected data attributes and empty-state copy

## Testing
- pytest tests/test_routes_smoke.py *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68f862bee35083218d2ff9960ce531d6