### PR TITLE
Document pytest usage in demo runbook

### DIFF
--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -25,6 +25,11 @@
 - Highlight pre-commit, tests, and PyInstaller packaging targets.
 - Reinforce Campus Board TODO assignments for teammates.
 
+## Test & QA Reminders
+- The `make test` target is a thin wrapper that executes plain `pytest` with no extra arguments.
+- You can also invoke tests directly by running `pytest` from the repository root to mirror CI behaviour.
+- Several test modules are currently marked with `@pytest.mark.skip` placeholders; seeing `s`/`SKIPPED` entries in the output is expected until the related TODOs are implemented.
+
 ## TODO Risks for Demo
 - Seeder not implemented; manual DB state may be required.
 - Charts and CSV imports pending.


### PR DESCRIPTION
## Summary
- note that the `make test` target runs plain pytest with no additional arguments
- add explicit CLI guidance for executing pytest from the repository root
- explain the current skipped tests and what to expect in the output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f862c04f2c8321869eb32ddb87692b