### PR TITLE
Update smoke test to cover home page rendering

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-import pytest
 from pocketsage import create_app
 
 
-@pytest.mark.skip(
-    reason="TODO(@qa-team): replace with entrypoint redirect test under new blueprint layout."
-)
-def test_home_redirect():
+def test_home_page_renders():
     app = create_app("development")
     client = app.test_client()
     response = client.get("/")
-    assert response.status_code in (301, 302)
+    assert response.status_code == 200
+    assert b"Welcome to PocketSage" in response.data


### PR DESCRIPTION
## Summary
- remove the skip from the smoke test now that the home blueprint serves content
- assert the root route responds with HTTP 200 and includes the landing page copy

## Testing
- pytest tests/test_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68f862c189688321b1cbe82c53884020