### PR TITLE
Group portfolio holdings by account with collapsible sections

### DIFF
--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -264,6 +264,88 @@ body {
     font-variant-numeric: tabular-nums;
 }
 
+.account-groups {
+    display: grid;
+    gap: 1rem;
+}
+
+.account-group {
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    background: rgba(255, 255, 255, 0.03);
+    overflow: hidden;
+}
+
+.account-summary {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    cursor: pointer;
+    font-weight: 600;
+    background: rgba(15, 23, 42, 0.35);
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.account-summary:focus-visible {
+    outline: 3px solid rgba(34, 197, 94, 0.6);
+    outline-offset: 2px;
+}
+
+.account-summary:hover {
+    background: rgba(15, 23, 42, 0.5);
+}
+
+.account-summary::-webkit-details-marker,
+.account-summary::marker {
+    display: none;
+}
+
+.account-summary-title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.account-name {
+    font-size: 1.05rem;
+}
+
+.account-meta {
+    display: flex;
+    gap: 0.75rem;
+    font-variant-numeric: tabular-nums;
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.9rem;
+}
+
+.account-summary-icon {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg);
+    transition: transform 0.2s ease;
+}
+
+.account-group[open] .account-summary-icon {
+    transform: rotate(-135deg);
+}
+
+.account-group[open] .account-summary {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.account-holdings {
+    padding: 0 1.25rem 1.25rem;
+}
+
+.account-share {
+    color: rgba(34, 197, 94, 0.85);
+}
+
 .upload-card {
     display: grid;
     gap: 1rem;

--- a/pocketsage/templates/portfolio/index.html
+++ b/pocketsage/templates/portfolio/index.html
@@ -37,36 +37,52 @@
       {% endif %}
     </section>
 
-    <section class="portfolio-holdings" aria-label="Holdings table">
+    <section class="portfolio-holdings" aria-label="Holdings by account">
       <h2>Holdings</h2>
-      {% if holdings %}
-        <div class="table-scroll">
-          <table class="holdings-table" role="grid">
-            <thead>
-              <tr>
-                <th scope="col">Symbol</th>
-                <th scope="col">Quantity</th>
-                <th scope="col">Average price</th>
-                <th scope="col">Market value</th>
-                <th scope="col">Allocation</th>
-                <th scope="col">Account</th>
-                <th scope="col">Currency</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for holding in holdings %}
-                <tr>
-                  <td data-label="Symbol">{{ holding.symbol }}</td>
-                  <td data-label="Quantity">{{ holding.quantity_display }}</td>
-                  <td data-label="Average price">{{ holding.avg_price_display }}</td>
-                  <td data-label="Market value">{{ holding.value_display }}</td>
-                  <td data-label="Allocation">{{ holding.allocation_display }}</td>
-                  <td data-label="Account">{{ holding.account or "—" }}</td>
-                  <td data-label="Currency">{{ holding.currency }}</td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
+      {% if account_groups %}
+        <div class="account-groups" role="list">
+          {% for account in account_groups %}
+            <details class="account-group" role="listitem"{% if loop.first %} open{% endif %}>
+              <summary class="account-summary" aria-controls="holdings-{{ account.key }}">
+                <span class="account-summary-title">
+                  <span class="account-name">{{ account.name }}</span>
+                  <span class="account-meta">
+                    <span class="account-subtotal" aria-label="Market value">{{ account.total_value_display }}</span>
+                    <span class="account-share" aria-label="Allocation share">{{ account.allocation_display }}</span>
+                  </span>
+                </span>
+                <span class="account-summary-icon" aria-hidden="true"></span>
+              </summary>
+              <div class="account-holdings" id="holdings-{{ account.key }}">
+                <div class="table-scroll">
+                  <table class="holdings-table" role="grid" aria-label="{{ account.name }} holdings">
+                    <thead>
+                      <tr>
+                        <th scope="col">Symbol</th>
+                        <th scope="col">Quantity</th>
+                        <th scope="col">Average price</th>
+                        <th scope="col">Market value</th>
+                        <th scope="col">Allocation</th>
+                        <th scope="col">Currency</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for holding in account.holdings %}
+                        <tr>
+                          <td data-label="Symbol">{{ holding.symbol }}</td>
+                          <td data-label="Quantity">{{ holding.quantity_display }}</td>
+                          <td data-label="Average price">{{ holding.avg_price_display }}</td>
+                          <td data-label="Market value">{{ holding.value_display }}</td>
+                          <td data-label="Allocation">{{ holding.allocation_display }}</td>
+                          <td data-label="Currency">{{ holding.currency }}</td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </details>
+          {% endfor %}
         </div>
       {% else %}
         <p class="empty">No holdings yet. Upload a CSV to see your portfolio here.</p>


### PR DESCRIPTION
## Summary
- group portfolio holdings by account and surface subtotals for each bucket
- render the portfolio view as collapsible per-account sections with updated markup
- add styling for the new controls while keeping keyboard accessibility intact

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68f862d304908321946e9cde4b342ff1