### PR TITLE
Add preview confirmation step to portfolio CSV import

### DIFF
--- a/pocketsage/blueprints/portfolio/routes.py
+++ b/pocketsage/blueprints/portfolio/routes.py
@@ -65,6 +65,7 @@ def _suggest_mapping(columns: Iterable[str]) -> dict[str, str | None]:
 
 def _normalize_rows(rows: Iterable[dict], mapping: dict[str, str | None]) -> list[dict]:
     normalized: list[dict] = []
+    permitted_keys = {canonical for canonical, column in mapping.items() if column}
     for row in rows:
         clean = {
             (key or "").strip().lower(): (str(value).strip() if value is not None else "")
@@ -73,7 +74,13 @@ def _normalize_rows(rows: Iterable[dict], mapping: dict[str, str | None]) -> lis
         for canonical, column in mapping.items():
             if column and column in clean:
                 clean[canonical] = clean[column]
-        normalized.append(clean)
+            elif not column:
+                clean.pop(canonical, None)
+        if permitted_keys:
+            filtered = {key: clean.get(key, "") for key in permitted_keys}
+        else:
+            filtered = {}
+        normalized.append(filtered)
     return normalized
 
 

--- a/pocketsage/static/js/main.js
+++ b/pocketsage/static/js/main.js
@@ -129,6 +129,19 @@ function initPortfolioUpload() {
     const fileLabel = uploadForm.querySelector("[data-file-label]");
     const progress = uploadForm.querySelector("[data-upload-progress]");
     const redirectUrl = uploadForm.dataset.redirect;
+    const previewSection = uploadForm.querySelector("[data-upload-preview]");
+    const mappingContainer = uploadForm.querySelector("[data-mapping-table]");
+    const sampleContainer = uploadForm.querySelector("[data-sample-table]");
+    const previewSummary = uploadForm.querySelector("[data-preview-summary]");
+    const confirmButton = uploadForm.querySelector("[data-confirm-import]");
+    const submitButton = uploadForm.querySelector("button[type='submit']");
+    const mappingInput = uploadForm.querySelector("[data-mapping-input]");
+
+    let currentMapping = {};
+    let availableColumns = [];
+    let previewSamples = [];
+    let previewAvailable = false;
+    let previewStale = false;
 
     const resetProgress = () => {
         if (!progress) {
@@ -148,44 +161,272 @@ function initPortfolioUpload() {
         progress.textContent = message;
     };
 
-    resetProgress();
+    const updatePreviewSummary = (message) => {
+        if (!previewSummary) {
+            return;
+        }
+        previewSummary.textContent = message;
+    };
 
-    if (fileInput) {
-        fileInput.addEventListener("change", () => {
-            if (fileInput.files && fileInput.files.length > 0) {
-                const [{ name }] = fileInput.files;
-                if (fileLabel) {
-                    fileLabel.textContent = name;
-                }
-                setProgress(`Ready to upload ${name}`, "ready");
+    const syncMappingInput = () => {
+        if (mappingInput) {
+            if (Object.keys(currentMapping).length > 0) {
+                mappingInput.value = JSON.stringify(currentMapping);
             } else {
-                if (fileLabel) {
-                    fileLabel.textContent = "Choose a CSV file";
-                }
-                resetProgress();
+                mappingInput.value = "";
             }
-        });
-    }
+        }
+    };
 
-    uploadForm.addEventListener("submit", async (event) => {
+    const resetPreview = () => {
+        previewAvailable = false;
+        previewStale = false;
+        currentMapping = {};
+        availableColumns = [];
+        previewSamples = [];
+        if (previewSection) {
+            previewSection.hidden = true;
+        }
+        if (mappingContainer) {
+            mappingContainer.innerHTML = "<p class=\"empty\">Run a preview to detect column mappings.</p>";
+        }
+        if (sampleContainer) {
+            sampleContainer.innerHTML = "<p class=\"empty\">Sample rows will appear after generating a preview.</p>";
+        }
+        if (confirmButton) {
+            confirmButton.hidden = true;
+            confirmButton.disabled = true;
+        }
+        updatePreviewSummary("Review detected mappings before importing.");
+        syncMappingInput();
+        updateConfirmState();
+    };
+
+    const updateConfirmState = () => {
+        if (!confirmButton) {
+            return;
+        }
+        confirmButton.hidden = !previewAvailable;
+        confirmButton.disabled = !previewAvailable || previewStale;
+        if (previewAvailable && previewStale) {
+            confirmButton.title = "Refresh the preview before importing.";
+        } else {
+            confirmButton.removeAttribute("title");
+        }
+    };
+
+    const renderMappingControls = () => {
+        if (!mappingContainer) {
+            return;
+        }
+
+        const canonicalFields = Object.keys(currentMapping);
+        if (canonicalFields.length === 0) {
+            mappingContainer.innerHTML = "<p class=\"empty\">No recognizable columns were detected.</p>";
+            return;
+        }
+
+        const table = document.createElement("table");
+        table.className = "preview-table";
+
+        const thead = document.createElement("thead");
+        thead.innerHTML = "<tr><th>Field</th><th>CSV column</th></tr>";
+        table.appendChild(thead);
+
+        const tbody = document.createElement("tbody");
+        canonicalFields
+            .sort()
+            .forEach((field) => {
+                const row = document.createElement("tr");
+                const labelCell = document.createElement("th");
+                labelCell.scope = "row";
+                labelCell.textContent = field.replace(/_/g, " ");
+
+                const selectCell = document.createElement("td");
+                const select = document.createElement("select");
+                select.name = `mapping-${field}`;
+
+                const emptyOption = document.createElement("option");
+                emptyOption.value = "";
+                emptyOption.textContent = "Ignore";
+                select.appendChild(emptyOption);
+
+                availableColumns.forEach((column) => {
+                    const option = document.createElement("option");
+                    option.value = column;
+                    option.textContent = column;
+                    select.appendChild(option);
+                });
+
+                select.value = currentMapping[field] || "";
+                select.addEventListener("change", () => {
+                    currentMapping[field] = select.value || null;
+                    previewStale = true;
+                    syncMappingInput();
+                    updateConfirmState();
+                    updatePreviewSummary("Mapping updated. Preview again to refresh sample data.");
+                    setProgress("Mapping updated. Preview again to refresh sample data.", "info");
+                    if (sampleContainer) {
+                        sampleContainer.innerHTML =
+                            "<p class=\"empty\">Preview is out of date. Generate a new preview to refresh sample rows.</p>";
+                    }
+                });
+
+                selectCell.appendChild(select);
+                row.appendChild(labelCell);
+                row.appendChild(selectCell);
+                tbody.appendChild(row);
+            });
+
+        table.appendChild(tbody);
+        mappingContainer.innerHTML = "";
+        mappingContainer.appendChild(table);
+    };
+
+    const renderSampleTable = () => {
+        if (!sampleContainer) {
+            return;
+        }
+
+        const activeFields = Object.entries(currentMapping)
+            .filter(([, column]) => column)
+            .map(([field]) => field)
+            .sort();
+
+        if (previewSamples.length === 0 || activeFields.length === 0) {
+            sampleContainer.innerHTML = "<p class=\"empty\">No sample rows available yet.</p>";
+            return;
+        }
+
+        const table = document.createElement("table");
+        table.className = "preview-table";
+
+        const thead = document.createElement("thead");
+        const headerRow = document.createElement("tr");
+        activeFields.forEach((field) => {
+            const cell = document.createElement("th");
+            cell.textContent = field.replace(/_/g, " ");
+            headerRow.appendChild(cell);
+        });
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        const tbody = document.createElement("tbody");
+        previewSamples.forEach((sample) => {
+            const row = document.createElement("tr");
+            activeFields.forEach((field) => {
+                const cell = document.createElement("td");
+                cell.textContent = sample[field] || "";
+                row.appendChild(cell);
+            });
+            tbody.appendChild(row);
+        });
+        table.appendChild(tbody);
+
+        sampleContainer.innerHTML = "";
+        sampleContainer.appendChild(table);
+    };
+
+    const buildFormData = (includePreviewFlag) => {
+        const formData = new FormData(uploadForm);
+        if (Object.keys(currentMapping).length > 0) {
+            formData.set("mapping", JSON.stringify(currentMapping));
+        } else {
+            formData.delete("mapping");
+        }
+        syncMappingInput();
+        if (includePreviewFlag) {
+            formData.set("preview", "1");
+        } else {
+            formData.delete("preview");
+        }
+        return formData;
+    };
+
+    const requestPreview = async () => {
         if (!fileInput || !fileInput.files || fileInput.files.length === 0) {
-            event.preventDefault();
             showFlash("Please choose a CSV file first.", "warning");
             setProgress("Select a CSV file before uploading.", "warning");
             return;
         }
 
-        event.preventDefault();
-        const submitButton = uploadForm.querySelector("button[type='submit']");
-        let skipUnlock = false;
         if (submitButton) {
             submitButton.disabled = true;
         }
-
-        setProgress("Uploading…", "progress");
+        setProgress("Analyzing CSV…", "progress");
+        previewStale = false;
+        updateConfirmState();
 
         try {
-            const formData = new FormData(uploadForm);
+            const formData = buildFormData(true);
+            const response = await fetch(uploadForm.action, {
+                method: "POST",
+                body: formData,
+                headers: { Accept: "application/json" },
+            });
+
+            const payload = await response.json().catch(() => ({}));
+            if (!response.ok || payload.error) {
+                const message = payload.message || "Unable to generate preview.";
+                setProgress(message, "warning");
+                showFlash(message, "warning");
+                resetPreview();
+                return;
+            }
+
+            previewAvailable = true;
+            previewStale = false;
+            currentMapping = payload.mapping || {};
+            availableColumns = payload.source_columns || [];
+            previewSamples = payload.samples || [];
+            syncMappingInput();
+
+            renderMappingControls();
+            renderSampleTable();
+
+            if (previewSection) {
+                previewSection.hidden = false;
+            }
+
+            const totalRows = payload.total_rows || 0;
+            const summary = totalRows
+                ? `Preview generated for ${totalRows} row${totalRows === 1 ? "" : "s"}.`
+                : "Preview generated.";
+            updatePreviewSummary(summary);
+            setProgress(payload.message || summary, "ready");
+        } catch (error) {
+            console.error("Preview request failed", error);
+            setProgress("Preview failed. Please try again.", "warning");
+            showFlash("Preview failed. Please try again.", "warning");
+            resetPreview();
+        } finally {
+            updateConfirmState();
+            if (submitButton) {
+                submitButton.disabled = false;
+            }
+        }
+    };
+
+    const finalizeImport = async () => {
+        if (previewStale) {
+            setProgress("Preview is out of date. Generate a new preview before importing.", "warning");
+            showFlash("Preview is out of date. Run the preview again first.", "warning");
+            return;
+        }
+        if (!previewAvailable) {
+            setProgress("Generate a preview before importing.", "warning");
+            showFlash("Generate a preview before importing.", "warning");
+            return;
+        }
+
+        let skipUnlock = false;
+        if (confirmButton) {
+            confirmButton.disabled = true;
+        }
+        setProgress("Importing holdings…", "progress");
+
+        try {
+            const formData = buildFormData(false);
             const response = await fetch(uploadForm.action, {
                 method: "POST",
                 body: formData,
@@ -197,6 +438,7 @@ function initPortfolioUpload() {
                 const message = payload.message || "Upload failed. Please try again.";
                 showFlash(message, "warning");
                 setProgress(message, "warning");
+                confirmButton && (confirmButton.disabled = false);
                 return;
             }
 
@@ -212,16 +454,47 @@ function initPortfolioUpload() {
             }
         } catch (error) {
             console.error("Portfolio upload failed", error);
-            if (submitButton) {
-                submitButton.disabled = false;
+            if (confirmButton) {
+                confirmButton.disabled = false;
             }
             uploadForm.submit();
         } finally {
-            if (submitButton && !skipUnlock) {
-                submitButton.disabled = false;
+            if (confirmButton && !skipUnlock) {
+                confirmButton.disabled = false;
             }
         }
+    };
+
+    resetProgress();
+    resetPreview();
+
+    if (fileInput) {
+        fileInput.addEventListener("change", () => {
+            if (fileInput.files && fileInput.files.length > 0) {
+                const [{ name }] = fileInput.files;
+                if (fileLabel) {
+                    fileLabel.textContent = name;
+                }
+                setProgress(`Ready to upload ${name}`, "ready");
+                resetPreview();
+            } else {
+                if (fileLabel) {
+                    fileLabel.textContent = "Choose a CSV file";
+                }
+                resetProgress();
+                resetPreview();
+            }
+        });
+    }
+
+    uploadForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        requestPreview();
     });
+
+    if (confirmButton) {
+        confirmButton.addEventListener("click", finalizeImport);
+    }
 }
 
 function safeParseJSON(value) {

--- a/pocketsage/templates/portfolio/upload.html
+++ b/pocketsage/templates/portfolio/upload.html
@@ -15,6 +15,7 @@
       data-redirect="{{ url_for('portfolio.list_portfolio') }}"
       aria-label="Upload portfolio CSV"
     >
+      <input type="hidden" name="mapping" data-mapping-input>
       <div class="upload-input">
         <label class="file-picker">
           <span class="file-picker-label" data-file-label>Choose a CSV file</span>
@@ -23,8 +24,17 @@
         <p class="upload-hint">Accepted columns: <code>symbol</code>, <code>quantity</code>, <code>avg_price</code>. Extra columns are ignored.</p>
       </div>
       <p class="upload-progress" data-upload-progress hidden>Waiting for file…</p>
+      <section class="upload-preview" data-upload-preview hidden>
+        <h2>Preview import</h2>
+        <p class="upload-preview-summary" data-preview-summary>Review detected mappings before importing.</p>
+        <div class="preview-mapping" data-mapping-table></div>
+        <div class="preview-samples" data-sample-table></div>
+        <div class="upload-preview-actions">
+          <button type="button" class="btn-primary" data-confirm-import disabled hidden>Import holdings</button>
+        </div>
+      </section>
       <div class="upload-actions">
-        <button type="submit" class="btn-primary">Import CSV</button>
+        <button type="submit" class="btn-primary">Preview import</button>
         <a class="btn-secondary" href="{{ url_for('portfolio.list_portfolio') }}">Back to portfolio</a>
       </div>
       <noscript>


### PR DESCRIPTION
## Summary
- extend the portfolio import route to surface mapping suggestions and row samples when previewing a CSV upload and honor user-provided overrides during the final import
- update the upload template and client-side script to present a preview stage with adjustable column mappings, sample data, and an explicit confirmation step before importing

## Testing
- `pytest` *(fails: missing flask dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f862d2814c8321a76d0f6a20fd08d1