### PR TITLE
Improve allocation bar styling and fallback

### DIFF
--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -1,6 +1,17 @@
 :root {
     color-scheme: light dark;
     font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+    --allocation-track: rgba(148, 163, 184, 0.25);
+    --allocation-fill-start: #22d3ee;
+    --allocation-fill-end: #3b82f6;
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --allocation-track: rgba(100, 116, 139, 0.3);
+        --allocation-fill-start: #0ea5e9;
+        --allocation-fill-end: #2563eb;
+    }
 }
 
 body {
@@ -221,7 +232,7 @@ body {
     position: relative;
     height: 0.65rem;
     border-radius: 999px;
-    background: rgba(148, 163, 184, 0.25);
+    background: var(--allocation-track);
     overflow: hidden;
 }
 
@@ -230,7 +241,7 @@ body {
     position: absolute;
     inset: 0;
     width: calc(var(--allocation) * 1%);
-    background: linear-gradient(90deg, #22d3ee, #3b82f6);
+    background: linear-gradient(90deg, var(--allocation-fill-start), var(--allocation-fill-end));
 }
 
 .allocation-value {

--- a/pocketsage/static/js/main.js
+++ b/pocketsage/static/js/main.js
@@ -5,7 +5,30 @@ const FINAL_JOB_STATUSES = new Set(["succeeded", "failed"]);
 document.addEventListener("DOMContentLoaded", () => {
     initAdminDashboard();
     initPortfolioUpload();
+    applyAllocationFallback();
 });
+
+function applyAllocationFallback() {
+    const supportsCustomProperties =
+        typeof window.CSS !== "undefined" &&
+        typeof window.CSS.supports === "function" &&
+        window.CSS.supports("(--allocation: 0)");
+
+    if (supportsCustomProperties) {
+        return;
+    }
+
+    document
+        .querySelectorAll(".allocation-bar-fill[data-allocation]")
+        .forEach((bar) => {
+            const value = Number.parseFloat(bar.dataset.allocation);
+            if (!Number.isFinite(value)) {
+                return;
+            }
+            const clamped = Math.max(0, Math.min(value, 100));
+            bar.style.width = `${clamped}%`;
+        });
+}
 
 function initAdminDashboard() {
     const adminRoot = document.querySelector("[data-admin-dashboard]");

--- a/pocketsage/templates/portfolio/index.html
+++ b/pocketsage/templates/portfolio/index.html
@@ -23,7 +23,7 @@
       {% if allocation %}
         <div class="allocation-chart" role="list">
           {% for item in allocation %}
-            <div class="allocation-row" role="listitem">
+            <div class="allocation-row" role="listitem" style="--allocation: {{ item.percentage }}">
               <div class="allocation-symbol">{{ item.symbol }}</div>
               <div class="allocation-bar" aria-hidden="true">
                 <div class="allocation-bar-fill" data-allocation="{{ item.percentage }}"></div>


### PR DESCRIPTION
## Summary
- expose allocation percentages via inline CSS custom properties for each portfolio allocation row
- add a JavaScript fallback that translates allocation data attributes into widths when CSS custom properties are unavailable
- tune allocation bar colors with theme-aware variables for better contrast in light and dark modes

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68f862d4125483219e4f7842494a6a92