### PR TITLE
Add habit creation form scaffolding

### DIFF
--- a/pocketsage/blueprints/habits/forms.py
+++ b/pocketsage/blueprints/habits/forms.py
@@ -1,20 +1,79 @@
-"""Habit form stubs."""
+"""Habit form definitions."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from datetime import time
+from enum import Enum
+from typing import Iterable
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 
-@dataclass(slots=True)
-class HabitForm:
-    """Placeholder for habit creation/edit form."""
+class HabitCadence(str, Enum):
+    """Supported cadence options for habits."""
 
-    name: str = ""
-    description: str = ""
-    cadence: str = "daily"
+    DAILY = "daily"
+    WEEKLY = "weekly"
+    CUSTOM = "custom"
 
-    def validate(self) -> bool:
-        """Validate habit inputs."""
 
-        # TODO(@habits-squad): implement validation + error messaging.
-        raise NotImplementedError
+class HabitForm(BaseModel):
+    """Form model for creating or editing a habit."""
+
+    model_config = ConfigDict(validate_default=False, str_strip_whitespace=True)
+
+    name: str = Field(default="", description="Short label for the habit", max_length=100)
+    description: str = Field(default="", description="Optional details about the habit", max_length=400)
+    cadence: HabitCadence = Field(default=HabitCadence.DAILY, description="Habit frequency")
+    custom_interval_days: int | None = Field(
+        default=None,
+        ge=1,
+        le=365,
+        description="Number of days between habit completions when using custom cadence",
+    )
+    reminders_enabled: bool = Field(default=True, description="Toggle habit reminders")
+    reminder_time: time | None = Field(default=time(hour=9), description="Preferred reminder time")
+    tags: list[str] = Field(default_factory=list, description="Optional list of habit tags")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        """Ensure the habit name is present when validating submissions."""
+
+        if not value or not value.strip():
+            raise ValueError("Please provide a habit name.")
+        return value
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def split_tags(cls, value: str | Iterable[str]) -> list[str] | Iterable[str]:
+        """Convert comma-separated tag strings into a list."""
+
+        if isinstance(value, str):
+            return [tag for tag in (part.strip() for part in value.split(",")) if tag]
+        return value
+
+    @model_validator(mode="after")
+    def ensure_custom_interval(self) -> "HabitForm":
+        """Require an interval when custom cadence is selected."""
+
+        if self.cadence is HabitCadence.CUSTOM and not self.custom_interval_days:
+            raise ValueError("Set the number of days for a custom cadence.")
+        return self
+
+    def validation_errors(self) -> dict[str, list[str]]:
+        """Return validation errors for the current payload."""
+
+        try:
+            HabitForm.model_validate(self.model_dump())
+        except ValidationError as exc:  # pragma: no cover - passthrough helper
+            structured: dict[str, list[str]] = {}
+            for error in exc.errors(include_url=False):
+                loc = error.get("loc", ())
+                key = loc[0] if loc else "__root__"
+                structured.setdefault(key, []).append(error.get("msg", "Invalid value"))
+            return structured
+        return {}
+
+
+__all__ = ["HabitCadence", "HabitForm"]

--- a/pocketsage/blueprints/habits/routes.py
+++ b/pocketsage/blueprints/habits/routes.py
@@ -7,6 +7,7 @@ from datetime import date
 from flask import flash, redirect, render_template, url_for
 
 from . import bp
+from .forms import HabitCadence, HabitForm
 
 
 @bp.get("/")
@@ -31,5 +32,6 @@ def toggle_habit(habit_id: int):
 def new_habit():
     """Render form for creating a new habit."""
 
-    # TODO(@habits-squad): supply HabitForm with defaults.
-    return render_template("habits/form.html")
+    form = HabitForm()
+    cadence_options = list(HabitCadence)
+    return render_template("habits/form.html", form=form, cadence_options=cadence_options)

--- a/pocketsage/blueprints/habits/routes.py
+++ b/pocketsage/blueprints/habits/routes.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, time
 
-from flask import flash, redirect, render_template, url_for
+from flask import flash, redirect, render_template, request, url_for
 
 from . import bp
 from .forms import HabitCadence, HabitForm
@@ -28,10 +28,38 @@ def toggle_habit(habit_id: int):
     return redirect(url_for("habits.list_habits"))
 
 
-@bp.get("/new")
+@bp.route("/new", methods=("GET", "POST"))
 def new_habit():
     """Render form for creating a new habit."""
 
     form = HabitForm()
+    errors: dict[str, list[str]] = {}
+    if request.method == "POST":
+        custom_interval_raw = request.form.get("custom_interval_days", "").strip()
+        reminder_time_raw = request.form.get("reminder_time", "").strip()
+        payload = {
+            "name": request.form.get("name", ""),
+            "description": request.form.get("description", ""),
+            "cadence": request.form.get("cadence", HabitCadence.DAILY.value),
+            "custom_interval_days": custom_interval_raw or None,
+            "reminders_enabled": "reminders_enabled" in request.form,
+            "reminder_time": None,
+            "tags": request.form.get("tags", ""),
+        }
+
+        if reminder_time_raw:
+            try:
+                payload["reminder_time"] = time.fromisoformat(reminder_time_raw)
+            except ValueError:
+                payload["reminder_time"] = None
+
+        form = HabitForm.model_construct(**payload)
+        errors = form.validation_errors()
+        if not errors:
+            flash("Habit saved! Tracking will be added soon.", "success")
+            return redirect(url_for("habits.list_habits"))
+
     cadence_options = list(HabitCadence)
-    return render_template("habits/form.html", form=form, cadence_options=cadence_options)
+    return render_template(
+        "habits/form.html", form=form, cadence_options=cadence_options, errors=errors
+    )

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -32,6 +32,126 @@ body {
     padding: 2rem;
 }
 
+.form-card {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1.75rem;
+    display: grid;
+    gap: 1.75rem;
+    max-width: 720px;
+}
+
+.form-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.field {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.field label,
+.field-label,
+.field legend {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.82);
+}
+
+.field-inline {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.input-control {
+    background: rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 0.6rem;
+    color: inherit;
+    font-size: 1rem;
+    padding: 0.75rem 0.9rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-control:focus {
+    outline: 2px solid #3b82f6;
+    outline-offset: 2px;
+    border-color: transparent;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35);
+}
+
+.input-control::placeholder {
+    color: rgba(148, 163, 184, 0.75);
+}
+
+.input-small {
+    max-width: 6rem;
+}
+
+.input-time {
+    max-width: 8.5rem;
+}
+
+.option-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.option {
+    align-items: center;
+    background: rgba(148, 163, 184, 0.1);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 0.65rem;
+    cursor: pointer;
+    display: inline-flex;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    font-weight: 500;
+}
+
+.option input {
+    accent-color: #22c55e;
+}
+
+.option-checkbox {
+    border-radius: 0.5rem;
+    padding: 0.35rem 0.75rem;
+}
+
+.reminder-controls {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.time-label {
+    font-weight: 500;
+    opacity: 0.75;
+}
+
+.field-hint {
+    font-size: 0.85rem;
+    color: rgba(148, 163, 184, 0.85);
+}
+
+.field-error {
+    color: #f97316;
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.form-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
 .flash-messages {
     margin-bottom: 1rem;
 }

--- a/pocketsage/templates/habits/form.html
+++ b/pocketsage/templates/habits/form.html
@@ -2,5 +2,113 @@
 {% block title %}New Habit · PocketSage{% endblock %}
 {% block content %}
   <h1>Create Habit</h1>
-  <p class="todo">TODO(@habits-squad): design form for cadence selection and reminders.</p>
+  {% set errors = errors if errors is defined else {} %}
+  <form method="post" action="{{ url_for('habits.new_habit') }}" class="form-card">
+    <div class="form-grid">
+      <div class="field">
+        <label for="name">Habit name</label>
+        <input
+          class="input-control"
+          type="text"
+          id="name"
+          name="name"
+          placeholder="Drink water"
+          value="{{ form.name }}"
+          required
+        >
+        {% if errors.get('name') %}
+          <p class="field-error">{{ errors['name'][0] }}</p>
+        {% endif %}
+      </div>
+
+      <div class="field">
+        <span id="cadence-label" class="field-label">Cadence</span>
+        <div class="option-group" role="radiogroup" aria-labelledby="cadence-label">
+          {% for option in cadence_options %}
+            <label class="option">
+              <input
+                type="radio"
+                name="cadence"
+                value="{{ option.value }}"
+                {% if form.cadence == option or form.cadence == option.value %}checked{% endif %}
+              >
+              <span>{{ option.value|capitalize }}</span>
+            </label>
+          {% endfor %}
+        </div>
+        {% if errors.get('cadence') %}
+          <p class="field-error">{{ errors['cadence'][0] }}</p>
+        {% endif %}
+      </div>
+
+      <div class="field">
+        <label for="custom_interval_days">Custom cadence</label>
+        <div class="field-inline">
+          <input
+            class="input-control input-small"
+            type="number"
+            id="custom_interval_days"
+            name="custom_interval_days"
+            min="1"
+            max="365"
+            placeholder="7"
+            value="{{ form.custom_interval_days if form.custom_interval_days is not none else '' }}"
+          >
+          <span class="field-hint">Days between completions when cadence is set to custom.</span>
+        </div>
+        {% if errors.get('custom_interval_days') %}
+          <p class="field-error">{{ errors['custom_interval_days'][0] }}</p>
+        {% elif errors.get('__root__') %}
+          <p class="field-error">{{ errors['__root__'][0] }}</p>
+        {% endif %}
+      </div>
+
+      <fieldset class="field">
+        <legend class="field-label">Reminders</legend>
+        <div class="reminder-controls">
+          <label class="option option-checkbox">
+            <input
+              type="checkbox"
+              name="reminders_enabled"
+              value="1"
+              {% if form.reminders_enabled %}checked{% endif %}
+            >
+            <span>Send reminders</span>
+          </label>
+          <label for="reminder_time" class="time-label">at</label>
+          <input
+            class="input-control input-time"
+            type="time"
+            id="reminder_time"
+            name="reminder_time"
+            value="{{ form.reminder_time.strftime('%H:%M') if form.reminder_time else '' }}"
+          >
+        </div>
+        {% if errors.get('reminder_time') %}
+          <p class="field-error">{{ errors['reminder_time'][0] }}</p>
+        {% endif %}
+      </fieldset>
+
+      <div class="field">
+        <label for="tags">Tags</label>
+        <input
+          class="input-control"
+          type="text"
+          id="tags"
+          name="tags"
+          placeholder="health, morning routine"
+          value="{{ form.tags | join(', ') }}"
+        >
+        <p class="field-hint">Separate tags with commas to group related habits.</p>
+        {% if errors.get('tags') %}
+          <p class="field-error">{{ errors['tags'][0] }}</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="form-actions">
+      <button type="submit" class="btn-primary">Save habit</button>
+      <a href="{{ url_for('habits.list_habits') }}" class="btn-link">Cancel</a>
+    </div>
+  </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement a Pydantic-based habit form with cadence, reminders, and tag helpers
- pass default form data to the new habit route and render structured controls
- add reusable form styling to support validation feedback on the habit form

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68f862dad4348321a8ff60fe67ad2ce6