### PR TITLE
Add ledger rollup summary cards and styling

### DIFF
--- a/pocketsage/blueprints/ledger/routes.py
+++ b/pocketsage/blueprints/ledger/routes.py
@@ -2,17 +2,211 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Mapping
+
 from flask import flash, redirect, render_template, request, url_for
 
 from . import bp
+
+
+@dataclass(frozen=True)
+class DemoTransaction:
+    """Lightweight structure used to populate the ledger prototype."""
+
+    occurred_at: datetime
+    amount: float
+    memo: str
+    category: str
+
+
+# Seed the prototype ledger with representative inflow and outflow data. The
+# sample spans two months so that the UI can surface a meaningful trend
+# indicator when comparing periods.
+_DEMO_TRANSACTIONS: tuple[DemoTransaction, ...] = (
+    DemoTransaction(
+        occurred_at=datetime(2024, 3, 1),
+        amount=4200.0,
+        memo="Salary · Acme Corp",
+        category="Income",
+    ),
+    DemoTransaction(
+        occurred_at=datetime(2024, 3, 2),
+        amount=-125.34,
+        memo="Groceries · Fresh Market",
+        category="Household",
+    ),
+    DemoTransaction(
+        occurred_at=datetime(2024, 3, 5),
+        amount=-89.5,
+        memo="Utilities · City Power",
+        category="Utilities",
+    ),
+    DemoTransaction(
+        occurred_at=datetime(2024, 3, 12),
+        amount=-230.0,
+        memo="Dining · Weekend outings",
+        category="Dining",
+    ),
+    DemoTransaction(
+        occurred_at=datetime(2024, 3, 18),
+        amount=150.0,
+        memo="Freelance · Design gig",
+        category="Income",
+    ),
+    DemoTransaction(
+        occurred_at=datetime(2024, 2, 29),
+        amount=4100.0,
+        memo="Salary · Acme Corp",
+        category="Income",
+    ),
+    DemoTransaction(
+        occurred_at=datetime(2024, 2, 21),
+        amount=-118.75,
+        memo="Groceries · Fresh Market",
+        category="Household",
+    ),
+    DemoTransaction(
+        occurred_at=datetime(2024, 2, 8),
+        amount=-92.1,
+        memo="Utilities · City Power",
+        category="Utilities",
+    ),
+)
+
+
+def _period_key(value: datetime) -> str:
+    return value.strftime("%Y-%m")
+
+
+def _period_label(key: str | None) -> str | None:
+    if not key:
+        return None
+    period_start = datetime.strptime(f"{key}-01", "%Y-%m-%d")
+    return period_start.strftime("%B %Y")
+
+
+def _format_currency(value: float, *, absolute: bool = False) -> str:
+    display_value = abs(value) if absolute else value
+    prefix = "-" if (not absolute and display_value < 0) else ""
+    return f"{prefix}$ {abs(display_value):,.2f}"
+
+
+def _summarize_transactions(
+    transactions: Iterable[DemoTransaction],
+) -> tuple[list[Mapping[str, object]], str | None, str | None]:
+    """Return rollup metrics and human-readable period labels."""
+
+    monthly_totals: dict[str, dict[str, float]] = defaultdict(
+        lambda: {"income": 0.0, "expenses": 0.0, "balance": 0.0}
+    )
+
+    for txn in transactions:
+        period = _period_key(txn.occurred_at)
+        bucket = monthly_totals[period]
+        if txn.amount >= 0:
+            bucket["income"] += txn.amount
+        else:
+            bucket["expenses"] += abs(txn.amount)
+        bucket["balance"] += txn.amount
+
+    if not monthly_totals:
+        return [], None, None
+
+    periods = sorted(monthly_totals.keys())
+    current_period_key = periods[-1]
+    previous_period_key = periods[-2] if len(periods) > 1 else None
+
+    current_label = _period_label(current_period_key)
+    previous_label = _period_label(previous_period_key)
+
+    metric_definitions = (
+        ("income", "Income", True),
+        ("expenses", "Expenses", True),
+        ("balance", "Net balance", False),
+    )
+
+    rollups: list[Mapping[str, object]] = []
+    for key, label, absolute in metric_definitions:
+        current_value = monthly_totals[current_period_key][key]
+        has_comparison = previous_period_key is not None
+        previous_value = (
+            monthly_totals[previous_period_key][key] if has_comparison else 0.0
+        )
+        change = current_value - previous_value if has_comparison else 0.0
+
+        direction = "flat"
+        if has_comparison:
+            if change > 1e-2:
+                direction = "up"
+            elif change < -1e-2:
+                direction = "down"
+        elif current_value > 0:
+            direction = "up"
+
+        percent_change: float | None = None
+        if has_comparison and abs(previous_value) > 1e-9:
+            percent_change = (change / previous_value) * 100
+
+        if not has_comparison:
+            trend_value = "First period"
+            trend_caption = "No prior period"
+            trend_sr_text = f"{label} for {current_label} with no prior comparison."
+        elif percent_change is None and abs(change) > 1e-2:
+            trend_value = "New this period"
+            trend_caption = f"Previously 0 in {previous_label}"
+            trend_sr_text = (
+                f"{label} introduced this period after no activity in {previous_label}."
+            )
+        else:
+            magnitude = abs(percent_change) if percent_change is not None else 0.0
+            if direction == "flat":
+                trend_value = "No change"
+                trend_sr_text = f"{label} unchanged compared to {previous_label}."
+            elif direction == "up":
+                trend_value = f"Up {magnitude:.1f}%"
+                trend_sr_text = (
+                    f"{label} increased {magnitude:.1f} percent compared to {previous_label}."
+                )
+            else:
+                trend_value = f"Down {magnitude:.1f}%"
+                trend_sr_text = (
+                    f"{label} decreased {magnitude:.1f} percent compared to {previous_label}."
+                )
+            trend_caption = f"vs {previous_label}" if previous_label else ""
+
+        rollups.append(
+            {
+                "key": key,
+                "label": label,
+                "formatted_amount": _format_currency(current_value, absolute=absolute),
+                "direction": direction,
+                "trend_value": trend_value,
+                "trend_caption": trend_caption,
+                "trend_sr_text": trend_sr_text,
+            }
+        )
+
+    return rollups, current_label, previous_label
 
 
 @bp.get("/")
 def list_transactions():
     """Display ledger transactions with filters and rollups."""
 
-    # TODO(@ledger-squad): wire repository filtering + pagination + rollup summary.
-    return render_template("ledger/index.html", filters=request.args)
+    rollups, current_period_label, previous_period_label = _summarize_transactions(
+        _DEMO_TRANSACTIONS
+    )
+
+    return render_template(
+        "ledger/index.html",
+        filters=request.args,
+        rollups=rollups,
+        current_period_label=current_period_label,
+        previous_period_label=previous_period_label,
+    )
 
 
 @bp.get("/new")

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -9,6 +9,18 @@ body {
     color: var(--text, #f5f5f5);
 }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .top-nav {
     background: #1f1f1f;
     padding: 0.75rem 1.5rem;
@@ -179,6 +191,7 @@ body {
     flex-wrap: wrap;
 }
 
+.card-surface,
 .portfolio-summary,
 .portfolio-allocation,
 .portfolio-holdings,
@@ -345,6 +358,93 @@ body {
 
 .upload-guidance li {
     line-height: 1.5;
+}
+
+.ledger-dashboard {
+    display: grid;
+    gap: 2rem;
+}
+
+.ledger-header {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.ledger-subtitle {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.ledger-rollups {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+}
+
+.ledger-rollup-card {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.ledger-rollup-header {
+    display: grid;
+    gap: 0.25rem;
+}
+
+.ledger-rollup-label {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.ledger-rollup-period {
+    margin: 0;
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.55);
+}
+
+.ledger-rollup-amount {
+    margin: 0;
+    font-size: clamp(1.75rem, 3vw, 2.5rem);
+    font-weight: 700;
+}
+
+.ledger-rollup-trend {
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.ledger-rollup-trend-icon {
+    font-size: 0.85rem;
+}
+
+.ledger-rollup-trend[data-direction="up"] {
+    color: #22c55e;
+}
+
+.ledger-rollup-trend[data-direction="down"] {
+    color: #f97316;
+}
+
+.ledger-rollup-trend[data-direction="flat"] {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.ledger-rollup-trend-value {
+    font-variant-numeric: tabular-nums;
+}
+
+.ledger-rollup-trend-caption {
+    font-weight: 400;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.65);
 }
 
 .job-item {

--- a/pocketsage/templates/ledger/index.html
+++ b/pocketsage/templates/ledger/index.html
@@ -1,6 +1,42 @@
 {% extends 'base.html' %}
 {% block title %}Ledger · PocketSage{% endblock %}
 {% block content %}
-  <h1>Ledger</h1>
-  <p class="todo">TODO(@ledger-squad): render transaction table, filters, and rollups.</p>
+  <section class="ledger-dashboard">
+    <header class="ledger-header">
+      <h1>Ledger</h1>
+      <p class="ledger-subtitle">Monitor cash flow and stay ahead of upcoming spending.</p>
+    </header>
+
+    <section class="ledger-rollups" aria-label="Cash flow summary{% if current_period_label %} for {{ current_period_label }}{% endif %}">
+      {% for metric in rollups %}
+        <article class="card-surface ledger-rollup-card" role="group" aria-labelledby="rollup-{{ metric.key }}">
+          <header class="ledger-rollup-header">
+            <p class="ledger-rollup-label" id="rollup-{{ metric.key }}">{{ metric.label }}</p>
+            {% if current_period_label %}
+              <p class="ledger-rollup-period">Current period: {{ current_period_label }}</p>
+            {% endif %}
+          </header>
+          <p class="ledger-rollup-amount">{{ metric.formatted_amount }}</p>
+          <p class="ledger-rollup-trend" data-direction="{{ metric.direction }}">
+            <span class="ledger-rollup-trend-icon" aria-hidden="true">
+              {% if metric.direction == 'up' %}
+                ▲
+              {% elif metric.direction == 'down' %}
+                ▼
+              {% else %}
+                ◆
+              {% endif %}
+            </span>
+            <span class="ledger-rollup-trend-value">{{ metric.trend_value }}</span>
+            {% if metric.trend_caption %}
+              <span class="ledger-rollup-trend-caption" aria-hidden="true">{{ metric.trend_caption }}</span>
+            {% endif %}
+            <span class="sr-only">{{ metric.trend_sr_text }}</span>
+          </p>
+        </article>
+      {% endfor %}
+    </section>
+
+    <p class="todo">Transaction table coming soon.</p>
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute income, expense, and balance rollups for the demo ledger data
- render the ledger dashboard with summary cards and accessible trend messaging
- expand shared card styling and add ledger-specific presentation rules

## Testing
- pytest -q *(fails: missing Flask dependency in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f862e1ca4083218ef7eb82c35141e2