### PR TITLE
Add responsive navigation toggle

### DIFF
--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -12,20 +12,115 @@ body {
 .top-nav {
     background: #1f1f1f;
     padding: 0.75rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.top-nav ul {
+.top-nav__toggle {
+    display: none;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 999px;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
+    padding: 0.35rem 0.9rem;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.top-nav__toggle:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: 3px;
+}
+
+.top-nav__toggle:hover {
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.24);
+    transform: translateY(-1px);
+}
+
+.top-nav__links {
     list-style: none;
     display: flex;
+    align-items: center;
     gap: 1rem;
     padding: 0;
     margin: 0;
+    transition: opacity 0.25s ease, max-height 0.3s ease, transform 0.25s ease;
+}
+
+.top-nav__links li {
+    transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .top-nav a {
     color: inherit;
     text-decoration: none;
     font-weight: 600;
+    display: inline-block;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.top-nav a:hover,
+.top-nav a:focus-visible {
+    background: rgba(255, 255, 255, 0.14);
+    color: #ffffff;
+    outline: none;
+}
+
+.top-nav a[aria-current="page"] {
+    background: #3b82f6;
+    color: #0f172a;
+}
+
+@media (max-width: 768px) {
+    .top-nav {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .top-nav__toggle {
+        display: inline-flex;
+        align-self: flex-end;
+    }
+
+    .top-nav__links {
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch;
+        margin-top: 0.5rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+        max-height: 0;
+        opacity: 0;
+        pointer-events: none;
+        transform: translateY(-0.5rem);
+    }
+
+    .top-nav__links li {
+        opacity: 0;
+        transform: translateY(-0.5rem);
+    }
+
+    .top-nav--open .top-nav__links {
+        max-height: 24rem;
+        opacity: 1;
+        pointer-events: auto;
+        transform: translateY(0);
+    }
+
+    .top-nav--open .top-nav__links li {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .container {

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -103,6 +103,10 @@ body {
         opacity: 0;
         pointer-events: none;
         transform: translateY(-0.5rem);
+        visibility: hidden;
+        overflow: hidden;
+        transition: opacity 0.25s ease, max-height 0.3s ease, transform 0.25s ease,
+            visibility 0s linear 0.3s;
     }
 
     .top-nav__links li {
@@ -115,6 +119,9 @@ body {
         opacity: 1;
         pointer-events: auto;
         transform: translateY(0);
+        visibility: visible;
+        transition: opacity 0.25s ease, max-height 0.3s ease, transform 0.25s ease,
+            visibility 0s linear 0s;
     }
 
     .top-nav--open .top-nav__links li {

--- a/pocketsage/static/js/main.js
+++ b/pocketsage/static/js/main.js
@@ -23,6 +23,17 @@ function initTopNav() {
         if (toggleButton) {
             toggleButton.setAttribute("aria-expanded", open ? "true" : "false");
         }
+        if (navLinks) {
+            const shouldDisable = !open && !mediaQuery.matches;
+            if (shouldDisable) {
+                navLinks.setAttribute("aria-hidden", "true");
+            } else {
+                navLinks.removeAttribute("aria-hidden");
+            }
+            if ("inert" in navLinks) {
+                navLinks.inert = shouldDisable;
+            }
+        }
     };
 
     const closeNav = () => setNavOpen(false);
@@ -56,8 +67,10 @@ function initTopNav() {
         if (mediaEvent.matches) {
             closeNav();
         }
+        setNavOpen(nav.classList.contains("top-nav--open"));
     };
 
+    setNavOpen(nav.classList.contains("top-nav--open"));
     handleMediaChange(mediaQuery);
     mediaQuery.addEventListener("change", handleMediaChange);
 }

--- a/pocketsage/static/js/main.js
+++ b/pocketsage/static/js/main.js
@@ -3,9 +3,64 @@
 const FINAL_JOB_STATUSES = new Set(["succeeded", "failed"]);
 
 document.addEventListener("DOMContentLoaded", () => {
+    initTopNav();
     initAdminDashboard();
     initPortfolioUpload();
 });
+
+function initTopNav() {
+    const nav = document.querySelector("[data-top-nav]");
+    if (!nav) {
+        return;
+    }
+
+    const toggleButton = nav.querySelector("[data-nav-toggle]");
+    const navLinks = nav.querySelector("[data-nav-links]");
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+
+    const setNavOpen = (open) => {
+        nav.classList.toggle("top-nav--open", open);
+        if (toggleButton) {
+            toggleButton.setAttribute("aria-expanded", open ? "true" : "false");
+        }
+    };
+
+    const closeNav = () => setNavOpen(false);
+
+    if (toggleButton) {
+        toggleButton.addEventListener("click", (event) => {
+            event.stopPropagation();
+            const isOpen = nav.classList.contains("top-nav--open");
+            setNavOpen(!isOpen);
+        });
+    }
+
+    if (navLinks) {
+        navLinks.addEventListener("click", (event) => {
+            if (event.target instanceof Element && event.target.closest("a")) {
+                closeNav();
+            }
+        });
+    }
+
+    document.addEventListener("click", (event) => {
+        if (!nav.classList.contains("top-nav--open")) {
+            return;
+        }
+        if (event.target instanceof Node && !nav.contains(event.target)) {
+            closeNav();
+        }
+    });
+
+    const handleMediaChange = (mediaEvent) => {
+        if (mediaEvent.matches) {
+            closeNav();
+        }
+    };
+
+    handleMediaChange(mediaQuery);
+    mediaQuery.addEventListener("change", handleMediaChange);
+}
 
 function initAdminDashboard() {
     const adminRoot = document.querySelector("[data-admin-dashboard]");

--- a/pocketsage/templates/_nav.html
+++ b/pocketsage/templates/_nav.html
@@ -1,9 +1,54 @@
-<nav class="top-nav">
-  <ul>
-    <li><a href="{{ url_for('ledger.list_transactions') }}">Ledger</a></li>
-    <li><a href="{{ url_for('habits.list_habits') }}">Habits</a></li>
-    <li><a href="{{ url_for('liabilities.list_liabilities') }}">Liabilities</a></li>
-    <li><a href="{{ url_for('portfolio.list_portfolio') }}">Portfolio</a></li>
-    <li><a href="{{ url_for('admin.dashboard') }}">Admin</a></li>
+{% set current_endpoint = request.endpoint %}
+<nav class="top-nav" data-top-nav>
+  <button
+    type="button"
+    class="top-nav__toggle"
+    aria-controls="top-nav-links"
+    aria-expanded="false"
+    data-nav-toggle
+  >
+    <span class="top-nav__toggle-label">Menu</span>
+  </button>
+  <ul id="top-nav-links" class="top-nav__links" data-nav-links>
+    <li>
+      <a
+        href="{{ url_for('ledger.list_transactions') }}"
+        {% if current_endpoint == 'ledger.list_transactions' %}aria-current="page"{% endif %}
+      >
+        Ledger
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ url_for('habits.list_habits') }}"
+        {% if current_endpoint == 'habits.list_habits' %}aria-current="page"{% endif %}
+      >
+        Habits
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ url_for('liabilities.list_liabilities') }}"
+        {% if current_endpoint == 'liabilities.list_liabilities' %}aria-current="page"{% endif %}
+      >
+        Liabilities
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ url_for('portfolio.list_portfolio') }}"
+        {% if current_endpoint == 'portfolio.list_portfolio' %}aria-current="page"{% endif %}
+      >
+        Portfolio
+      </a>
+    </li>
+    <li>
+      <a
+        href="{{ url_for('admin.dashboard') }}"
+        {% if current_endpoint == 'admin.dashboard' %}aria-current="page"{% endif %}
+      >
+        Admin
+      </a>
+    </li>
   </ul>
 </nav>


### PR DESCRIPTION
## Summary
- add an accessible toggle button and aria-current indicators to the top navigation template
- style the top navigation for responsive layouts with animated open and close states
- add a JavaScript helper to toggle the menu and close it on navigation or outside clicks

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68f862e634c48321b4238207da7bfda2