### PR TITLE
Add overview dashboard blueprint and navigation link

### DIFF
--- a/pocketsage/__init__.py
+++ b/pocketsage/__init__.py
@@ -27,6 +27,7 @@ def _resolve_config(name: str | None) -> type[BaseConfig]:
 def _blueprint_paths() -> Iterable[str]:
     """Yield blueprint import paths registered by the framework owner."""
 
+    yield "pocketsage.blueprints.overview"
     yield "pocketsage.blueprints.home"
     yield "pocketsage.blueprints.ledger"
     yield "pocketsage.blueprints.habits"
@@ -72,6 +73,9 @@ def _register_blueprints(app: Flask) -> None:
     for dotted_path in _blueprint_paths():
         module = import_module(dotted_path)
         blueprint = getattr(module, "bp")
+        init_hook = getattr(module, "init_app", None)
+        if callable(init_hook):
+            init_hook(app)
         app.register_blueprint(blueprint)
     # TODO(@qa-team): add coverage ensuring blueprint endpoints respond with 200
     #   and include expected template context variables.

--- a/pocketsage/blueprints/overview/__init__.py
+++ b/pocketsage/blueprints/overview/__init__.py
@@ -1,0 +1,26 @@
+"""Overview blueprint package."""
+
+from __future__ import annotations
+
+from flask import Blueprint, Flask
+
+bp = Blueprint(
+    "overview",
+    __name__,
+    url_prefix="/overview",
+    template_folder="../../templates/overview",
+)
+
+
+def init_app(app: Flask) -> None:
+    """Attach overview helpers to the Flask application."""
+
+    from .services import load_overview_summary
+
+    state = app.extensions.setdefault("overview", {})
+    state["summary_loader"] = load_overview_summary
+
+
+from . import routes  # noqa: E402,F401 - ensure routes register
+
+__all__ = ["bp", "init_app"]

--- a/pocketsage/blueprints/overview/routes.py
+++ b/pocketsage/blueprints/overview/routes.py
@@ -1,0 +1,26 @@
+"""Overview dashboard routes."""
+
+from __future__ import annotations
+
+from flask import current_app, render_template
+
+from . import bp
+from .services import load_overview_summary
+
+
+def _resolve_summary_loader():
+    state = current_app.extensions.get("overview", {})
+    loader = state.get("summary_loader")
+    if callable(loader):
+        return loader
+    return load_overview_summary
+
+
+@bp.get("/")
+def dashboard():
+    """Render the portfolio and wellness overview."""
+
+    summary_loader = _resolve_summary_loader()
+    summary = summary_loader()
+
+    return render_template("overview/index.html", summary=summary)

--- a/pocketsage/blueprints/overview/services.py
+++ b/pocketsage/blueprints/overview/services.py
@@ -57,6 +57,7 @@ def load_overview_summary() -> dict:
 
         # Habits -------------------------------------------------------------
         habits = session.exec(select(Habit)).all()
+        active_habit_count = sum(1 for habit in habits if habit.is_active)
         entries = session.exec(select(HabitEntry)).all()
         today = date.today()
         week_start = today - timedelta(days=6)
@@ -109,7 +110,7 @@ def load_overview_summary() -> dict:
             "recent_spending": recent_spending,
         },
         "habits": {
-            "active": sum(1 for habit in habits if habit.is_active),
+            "active": active_habit_count,
             "total": len(habits),
             "completions_today": completions_today,
             "weekly_completions": weekly_completions,

--- a/pocketsage/blueprints/overview/services.py
+++ b/pocketsage/blueprints/overview/services.py
@@ -1,0 +1,128 @@
+"""Data loaders for the overview dashboard."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Iterable
+
+from sqlmodel import select
+
+from ...extensions import session_scope
+from ...models import Habit, HabitEntry, Liability, Transaction
+from ..portfolio.repository import SqlModelPortfolioRepository
+
+
+@dataclass(slots=True)
+class HoldingHighlight:
+    symbol: str
+    value: float
+    allocation_pct: float
+
+
+def _compute_current_streak(entries: Iterable[HabitEntry], *, today: date) -> int:
+    """Return the length of the current streak for the provided entries."""
+
+    streak = 0
+    # Sort newest to oldest to calculate consecutive days from today backward.
+    for entry in sorted(entries, key=lambda item: item.occurred_on, reverse=True):
+        expected = today - timedelta(days=streak)
+        if entry.occurred_on == expected:
+            streak += 1
+            continue
+        if entry.occurred_on > expected:
+            # Entries newer than the expected day (e.g., duplicate completions) are skipped.
+            continue
+        break
+    return streak
+
+
+def load_overview_summary() -> dict:
+    """Gather summary statistics used by the overview dashboard."""
+
+    with session_scope() as session:
+        # Ledger / balances --------------------------------------------------
+        transactions = session.exec(select(Transaction)).all()
+        total_inflow = sum(float(tx.amount) for tx in transactions if tx.amount > 0)
+        total_outflow = sum(-float(tx.amount) for tx in transactions if tx.amount < 0)
+        net_balance = total_inflow - total_outflow
+
+        thirty_days_ago = datetime.utcnow() - timedelta(days=30)
+        recent_spending = sum(
+            -float(tx.amount)
+            for tx in transactions
+            if tx.amount < 0 and tx.occurred_at >= thirty_days_ago
+        )
+
+        # Habits -------------------------------------------------------------
+        habits = session.exec(select(Habit)).all()
+        entries = session.exec(select(HabitEntry)).all()
+        today = date.today()
+        week_start = today - timedelta(days=6)
+        completions_today = sum(1 for entry in entries if entry.occurred_on == today)
+        weekly_completions = sum(1 for entry in entries if entry.occurred_on >= week_start)
+
+        entries_by_habit: dict[int, list[HabitEntry]] = defaultdict(list)
+        for entry in entries:
+            entries_by_habit[entry.habit_id].append(entry)
+        best_streak = max(
+            (_compute_current_streak(habit_entries, today=today) for habit_entries in entries_by_habit.values()),
+            default=0,
+        )
+
+        # Liabilities -------------------------------------------------------
+        liabilities = session.exec(select(Liability)).all()
+        total_liability_balance = sum(float(item.balance or 0.0) for item in liabilities)
+        average_apr = (
+            sum(float(item.apr or 0.0) for item in liabilities) / len(liabilities)
+            if liabilities
+            else 0.0
+        )
+
+        # Portfolio ---------------------------------------------------------
+        repo = SqlModelPortfolioRepository(session)
+        holdings = list(repo.list_holdings())
+        allocation_summary = repo.allocation_summary()
+        total_portfolio_value = float(allocation_summary.get("total_value", 0.0) or 0.0)
+        allocation_map = allocation_summary.get("allocation", {})
+
+        holding_highlights: list[HoldingHighlight] = []
+        for holding in holdings:
+            quantity = float(holding.quantity or 0.0)
+            avg_price = float(holding.avg_price or 0.0)
+            value = quantity * avg_price
+            if value <= 0:
+                continue
+            allocation_pct = float(allocation_map.get(holding.symbol, 0.0) * 100)
+            holding_highlights.append(
+                HoldingHighlight(symbol=holding.symbol, value=value, allocation_pct=allocation_pct)
+            )
+
+    holding_highlights.sort(key=lambda h: h.value, reverse=True)
+
+    return {
+        "balances": {
+            "net": net_balance,
+            "inflow": total_inflow,
+            "outflow": total_outflow,
+            "recent_spending": recent_spending,
+        },
+        "habits": {
+            "active": sum(1 for habit in habits if habit.is_active),
+            "total": len(habits),
+            "completions_today": completions_today,
+            "weekly_completions": weekly_completions,
+            "best_streak": best_streak,
+        },
+        "liabilities": {
+            "count": len(liabilities),
+            "total_balance": total_liability_balance,
+            "average_apr": average_apr,
+        },
+        "portfolio": {
+            "holdings": len(holdings),
+            "total_value": total_portfolio_value,
+            "top_holdings": holding_highlights[:3],
+        },
+    }

--- a/pocketsage/templates/_nav.html
+++ b/pocketsage/templates/_nav.html
@@ -1,9 +1,23 @@
+{% set endpoint = request.endpoint or '' %}
 <nav class="top-nav">
   <ul>
-    <li><a href="{{ url_for('ledger.list_transactions') }}">Ledger</a></li>
-    <li><a href="{{ url_for('habits.list_habits') }}">Habits</a></li>
-    <li><a href="{{ url_for('liabilities.list_liabilities') }}">Liabilities</a></li>
-    <li><a href="{{ url_for('portfolio.list_portfolio') }}">Portfolio</a></li>
-    <li><a href="{{ url_for('admin.dashboard') }}">Admin</a></li>
+    <li class="{% if endpoint.startswith('overview.') %}active{% endif %}">
+      <a href="{{ url_for('overview.dashboard') }}"{% if endpoint.startswith('overview.') %} aria-current="page"{% endif %}>Overview</a>
+    </li>
+    <li class="{% if endpoint.startswith('ledger.') %}active{% endif %}">
+      <a href="{{ url_for('ledger.list_transactions') }}"{% if endpoint.startswith('ledger.') %} aria-current="page"{% endif %}>Ledger</a>
+    </li>
+    <li class="{% if endpoint.startswith('habits.') %}active{% endif %}">
+      <a href="{{ url_for('habits.list_habits') }}"{% if endpoint.startswith('habits.') %} aria-current="page"{% endif %}>Habits</a>
+    </li>
+    <li class="{% if endpoint.startswith('liabilities.') %}active{% endif %}">
+      <a href="{{ url_for('liabilities.list_liabilities') }}"{% if endpoint.startswith('liabilities.') %} aria-current="page"{% endif %}>Liabilities</a>
+    </li>
+    <li class="{% if endpoint.startswith('portfolio.') %}active{% endif %}">
+      <a href="{{ url_for('portfolio.list_portfolio') }}"{% if endpoint.startswith('portfolio.') %} aria-current="page"{% endif %}>Portfolio</a>
+    </li>
+    <li class="{% if endpoint.startswith('admin.') %}active{% endif %}">
+      <a href="{{ url_for('admin.dashboard') }}"{% if endpoint.startswith('admin.') %} aria-current="page"{% endif %}>Admin</a>
+    </li>
   </ul>
 </nav>

--- a/pocketsage/templates/overview/index.html
+++ b/pocketsage/templates/overview/index.html
@@ -1,0 +1,104 @@
+{% extends 'base.html' %}
+{% block title %}Overview · PocketSage{% endblock %}
+{% block content %}
+  <h1>Overview</h1>
+  <section class="overview-cards">
+    <article class="card">
+      <h2>Balances</h2>
+      <p class="metric">{{ '${:,.2f}'.format(summary.balances.net) }}</p>
+      <dl>
+        <div>
+          <dt>Total inflow</dt>
+          <dd>{{ '${:,.2f}'.format(summary.balances.inflow) }}</dd>
+        </div>
+        <div>
+          <dt>Total outflow</dt>
+          <dd>{{ '${:,.2f}'.format(summary.balances.outflow) }}</dd>
+        </div>
+        <div>
+          <dt>Spending (30 days)</dt>
+          <dd>{{ '${:,.2f}'.format(summary.balances.recent_spending) }}</dd>
+        </div>
+      </dl>
+      <a class="cta" href="{{ url_for('ledger.list_transactions') }}">View ledger</a>
+    </article>
+
+    <article class="card">
+      <h2>Habits</h2>
+      <p class="metric">{{ summary.habits.active }} active</p>
+      <dl>
+        <div>
+          <dt>Tracked habits</dt>
+          <dd>{{ summary.habits.total }}</dd>
+        </div>
+        <div>
+          <dt>Completions today</dt>
+          <dd>{{ summary.habits.completions_today }}</dd>
+        </div>
+        <div>
+          <dt>Completions (7 days)</dt>
+          <dd>{{ summary.habits.weekly_completions }}</dd>
+        </div>
+        <div>
+          <dt>Best streak</dt>
+          <dd>{{ summary.habits.best_streak }}</dd>
+        </div>
+      </dl>
+      <a class="cta" href="{{ url_for('habits.list_habits') }}">Go to habits</a>
+    </article>
+
+    <article class="card">
+      <h2>Liabilities</h2>
+      <p class="metric">{{ '${:,.2f}'.format(summary.liabilities.total_balance) }}</p>
+      <dl>
+        <div>
+          <dt>Accounts</dt>
+          <dd>{{ summary.liabilities.count }}</dd>
+        </div>
+        <div>
+          <dt>Average APR</dt>
+          <dd>{{ '{:.2f}%'.format(summary.liabilities.average_apr) }}</dd>
+        </div>
+      </dl>
+      <a class="cta" href="{{ url_for('liabilities.list_liabilities') }}">Review liabilities</a>
+    </article>
+
+    <article class="card">
+      <h2>Portfolio</h2>
+      <p class="metric">{{ '${:,.2f}'.format(summary.portfolio.total_value) }}</p>
+      <dl>
+        <div>
+          <dt>Holdings tracked</dt>
+          <dd>{{ summary.portfolio.holdings }}</dd>
+        </div>
+        {% if summary.portfolio.top_holdings %}
+          <div>
+            <dt>Top holdings</dt>
+            <dd>
+              <ul class="inline-list">
+              {% for holding in summary.portfolio.top_holdings %}
+                <li>
+                  {{ holding.symbol }}
+                  <span class="muted">({{ '{:,.2f}%'.format(holding.allocation_pct) }})</span>
+                </li>
+              {% endfor %}
+              </ul>
+            </dd>
+          </div>
+        {% endif %}
+      </dl>
+      <a class="cta" href="{{ url_for('portfolio.list_portfolio') }}">Open portfolio</a>
+    </article>
+  </section>
+
+  <section class="quick-links">
+    <h2>Quick links</h2>
+    <ul>
+      <li><a href="{{ url_for('ledger.list_transactions') }}">Ledger</a></li>
+      <li><a href="{{ url_for('habits.list_habits') }}">Habits</a></li>
+      <li><a href="{{ url_for('liabilities.list_liabilities') }}">Liabilities</a></li>
+      <li><a href="{{ url_for('portfolio.list_portfolio') }}">Portfolio</a></li>
+      <li><a href="{{ url_for('admin.dashboard') }}">Admin</a></li>
+    </ul>
+  </section>
+{% endblock %}

--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -17,6 +17,7 @@ def client():
 @pytest.mark.parametrize(
     "path",
     [
+        "/overview/",
         "/",
         "/ledger/",
         "/ledger/new",


### PR DESCRIPTION
## Summary
- add an overview blueprint that registers a summary loader and renders the new dashboard template
- surface balance, habit, liability, and portfolio highlights plus quick links on the overview page
- register the blueprint in the app factory, update navigation, and extend route smoke coverage

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68f862e6e38483219fb28c34221ec42a