### PR TITLE
Document blueprint routing prefixes in demo runbook

### DIFF
--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -29,3 +29,42 @@
 - Seeder not implemented; manual DB state may be required.
 - Charts and CSV imports pending.
 - Tests currently skipped; mention roadmap for coverage.
+
+## Blueprint Routing Overview
+
+PocketSage exposes its major feature areas via Flask blueprints. Use the following
+reference when hitting routes during manual testing:
+
+- **Home (`pocketsage.blueprints.home`)**
+  - **Base path:** `/` (no blueprint `url_prefix`). Visiting `/` serves the landing
+    page; Flask redirects `/` requests that omit the trailing slash as needed.
+  - **Key routes:** `GET /`.
+- **Admin (`pocketsage.blueprints.admin`)**
+  - **Base path:** `/admin/` (`url_prefix="/admin"`; Flask enforces the trailing
+    slash on the dashboard route defined as `@bp.get("/")`).
+  - **Key routes:** `GET /admin/`, `POST /admin/seed-demo`, `POST /admin/export`,
+    `GET /admin/export/download`, `GET /admin/jobs/<job_id>`.
+- **Habits (`pocketsage.blueprints.habits`)**
+  - **Base path:** `/habits/` (`url_prefix="/habits"`; expect trailing-slash
+    redirects for the index route).
+  - **Key routes:** `GET /habits/`, `GET /habits/new`,
+    `POST /habits/<habit_id>/toggle`.
+- **Ledger (`pocketsage.blueprints.ledger`)**
+  - **Base path:** `/ledger/` (`url_prefix="/ledger"`; trailing slash enforced on
+    the index route).
+  - **Key routes:** `GET /ledger/`, `GET /ledger/new`, `POST /ledger/`,
+    `GET /ledger/<transaction_id>/edit`, `POST /ledger/<transaction_id>`.
+- **Liabilities (`pocketsage.blueprints.liabilities`)**
+  - **Base path:** `/liabilities/` (`url_prefix="/liabilities"`; trailing slash
+    enforced on the index route).
+  - **Key routes:** `GET /liabilities/`, `GET /liabilities/new`,
+    `POST /liabilities/<liability_id>/recalculate`.
+- **Portfolio (`pocketsage.blueprints.portfolio`)**
+  - **Base path:** `/portfolio/` (`url_prefix="/portfolio"`; trailing slash
+    enforced on the holdings index).
+  - **Key routes:** `GET /portfolio/`, `POST /portfolio/import`,
+    `GET /portfolio/upload`, `GET /portfolio/export`.
+
+All route decorators use Flask's default strict-slash behavior: define index
+routes with `"/"` so Flask issues redirects for missing trailing slashes, while
+subroutes such as `/export` or `/new` do not carry trailing slashes.


### PR DESCRIPTION
## Summary
- add a blueprint routing overview to the demo runbook
- document each blueprint's url prefix, trailing slash behavior, and notable subroutes for testers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f862b17cbc8321b6aa0e830816b689