### PR TITLE
Document portfolio context verification

### DIFF
--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -29,3 +29,8 @@
 - Seeder not implemented; manual DB state may be required.
 - Charts and CSV imports pending.
 - Tests currently skipped; mention roadmap for coverage.
+
+## Portfolio Context Verification
+- **Template compatibility:** `list_portfolio` supplies `holdings`, `total_value`, `allocation`, `upload_url`, and `export_url`, matching the variables referenced in `templates/portfolio/index.html`. No discrepancies were found between the view context keys and the template expectations.
+- **Data population:** Holdings rows include the display-friendly fields (`quantity_display`, `avg_price_display`, `value_display`, `allocation_display`, `account`, `currency`) that the template renders. Allocation entries provide `symbol` and `percentage`, which back both the chart rows and the percentage labels. Upload and export buttons are wired to `portfolio.upload_portfolio` and `portfolio.export_holdings`, respectively.
+- **Follow-up:** No remediation needed at this time. Revisit if the template or view contracts change so that feature teams can react quickly to any newly introduced mismatches.


### PR DESCRIPTION
## Summary
- capture the portfolio context/template parity check in the demo runbook for downstream feature teams

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f862bd8d10832196fce1e68cf22cbb