### PR TITLE
Implement demo data seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Framework Owner checkpoint for the PocketSage desktop-first Flask app. Focus are
 - `make test` → pytest (currently skipped TODOs)
 - `make lint` → ruff + black check
 - `make package` → PyInstaller stub build
-- `make demo-seed` → placeholder seeding script (raises TODO)
+- `make demo-seed` → populate the local database with curated demo data
 
 ## Configuration Flags
 - `.env` values prefixed with `POCKETSAGE_`
@@ -55,3 +55,18 @@ Framework Owner checkpoint for the PocketSage desktop-first Flask app. Focus are
 - Fill Admin tasks, seeding, and export flows
 
 See `TODO.md` for the full itemization with owners.
+
+## Demo Data Seeding
+
+Run the demo seeding script whenever you need a representative dataset for manual
+testing:
+
+- `make demo-seed`
+- or `python scripts/seed_demo.py`
+
+The script applies upserts instead of blind inserts so it can be executed
+multiple times without duplicating rows. Categories are keyed by slug,
+transactions by their synthetic `external_id`, habits by name (including habit
+entries by date), and liabilities by name. This ensures the seed remains
+idempotent while still refreshing values such as balances, descriptions, or
+transaction memos on subsequent runs.

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -2,8 +2,20 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime, timezone
+
+from sqlmodel import select
+
 from pocketsage import create_app
 from pocketsage.extensions import session_scope
+from pocketsage.models import (
+    Account,
+    Category,
+    Habit,
+    HabitEntry,
+    Liability,
+    Transaction,
+)
 
 
 def seed_demo() -> None:
@@ -11,9 +23,189 @@ def seed_demo() -> None:
 
     app = create_app("development")
     with app.app_context():
-        with session_scope():
-            # TODO(@admin-squad): insert demo transactions, habits, liabilities, and categories.
-            raise NotImplementedError("Demo seed not yet implemented")
+        with session_scope() as session:
+            category_specs = [
+                {
+                    "name": "Groceries",
+                    "slug": "groceries",
+                    "category_type": "expense",
+                    "color": "#4CAF50",
+                },
+                {
+                    "name": "Dining Out",
+                    "slug": "dining-out",
+                    "category_type": "expense",
+                    "color": "#FF9800",
+                },
+                {
+                    "name": "Utilities",
+                    "slug": "utilities",
+                    "category_type": "expense",
+                    "color": "#03A9F4",
+                },
+                {
+                    "name": "Salary",
+                    "slug": "salary",
+                    "category_type": "income",
+                    "color": "#8BC34A",
+                },
+            ]
+
+            category_map: dict[str, Category] = {}
+            for spec in category_specs:
+                existing = session.exec(
+                    select(Category).where(Category.slug == spec["slug"])
+                ).one_or_none()
+                if existing is None:
+                    existing = Category(**spec)
+                    session.add(existing)
+                    session.flush()
+                else:
+                    existing.name = spec["name"]
+                    existing.category_type = spec["category_type"]
+                    existing.color = spec["color"]
+                category_map[spec["slug"]] = existing
+
+            account = session.exec(
+                select(Account).where(Account.name == "Demo Checking")
+            ).one_or_none()
+            if account is None:
+                account = Account(name="Demo Checking", currency="USD")
+                session.add(account)
+                session.flush()
+
+            transaction_specs = [
+                {
+                    "external_id": "demo-tx-001",
+                    "occurred_at": datetime(2024, 1, 5, 13, 30, tzinfo=timezone.utc),
+                    "amount": -58.23,
+                    "memo": "Grocery Run",
+                    "category_slug": "groceries",
+                },
+                {
+                    "external_id": "demo-tx-002",
+                    "occurred_at": datetime(2024, 1, 8, 19, 45, tzinfo=timezone.utc),
+                    "amount": -32.5,
+                    "memo": "Dinner with friends",
+                    "category_slug": "dining-out",
+                },
+                {
+                    "external_id": "demo-tx-003",
+                    "occurred_at": datetime(2024, 1, 10, 8, 0, tzinfo=timezone.utc),
+                    "amount": -90.0,
+                    "memo": "Electric bill",
+                    "category_slug": "utilities",
+                },
+                {
+                    "external_id": "demo-tx-004",
+                    "occurred_at": datetime(2024, 1, 15, 12, 0, tzinfo=timezone.utc),
+                    "amount": 2800.0,
+                    "memo": "Monthly salary",
+                    "category_slug": "salary",
+                },
+            ]
+
+            for spec in transaction_specs:
+                existing = session.exec(
+                    select(Transaction).where(Transaction.external_id == spec["external_id"])
+                ).one_or_none()
+                if existing is None:
+                    existing = Transaction(external_id=spec["external_id"])
+                    session.add(existing)
+                existing.occurred_at = spec["occurred_at"]
+                existing.amount = spec["amount"]
+                existing.memo = spec["memo"]
+                existing.category_id = category_map[spec["category_slug"]].id
+                existing.account_id = account.id
+                existing.currency = account.currency
+
+            habit_specs = [
+                {
+                    "name": "Morning Run",
+                    "description": "Run at least 2 miles before work.",
+                    "cadence": "daily",
+                    "entries": [
+                        (date(2024, 1, 6), 1),
+                        (date(2024, 1, 7), 0),
+                        (date(2024, 1, 8), 1),
+                    ],
+                },
+                {
+                    "name": "Review Budget",
+                    "description": "Check spending against the monthly plan.",
+                    "cadence": "weekly",
+                    "entries": [
+                        (date(2024, 1, 5), 1),
+                        (date(2024, 1, 12), 1),
+                    ],
+                },
+            ]
+
+            for spec in habit_specs:
+                existing = session.exec(
+                    select(Habit).where(Habit.name == spec["name"])
+                ).one_or_none()
+                if existing is None:
+                    existing = Habit(
+                        name=spec["name"],
+                        description=spec["description"],
+                        cadence=spec["cadence"],
+                    )
+                    session.add(existing)
+                    session.flush()
+                else:
+                    existing.description = spec["description"]
+                    existing.cadence = spec["cadence"]
+                    if not existing.is_active:
+                        existing.is_active = True
+
+                entries = {
+                    entry.occurred_on: entry
+                    for entry in session.exec(
+                        select(HabitEntry).where(HabitEntry.habit_id == existing.id)
+                    ).all()
+                }
+                for occurred_on, value in spec["entries"]:
+                    entry = entries.get(occurred_on)
+                    if entry is None:
+                        session.add(
+                            HabitEntry(
+                                habit_id=existing.id,
+                                occurred_on=occurred_on,
+                                value=value,
+                            )
+                        )
+                    else:
+                        entry.value = value
+
+            liability_specs = [
+                {
+                    "name": "Student Loan",
+                    "balance": 12500.0,
+                    "apr": 4.5,
+                    "minimum_payment": 150.0,
+                    "due_day": 15,
+                },
+                {
+                    "name": "Credit Card",
+                    "balance": 2300.0,
+                    "apr": 19.99,
+                    "minimum_payment": 65.0,
+                    "due_day": 10,
+                },
+            ]
+
+            for spec in liability_specs:
+                existing = session.exec(
+                    select(Liability).where(Liability.name == spec["name"])
+                ).one_or_none()
+                if existing is None:
+                    session.add(Liability(**spec))
+                else:
+                    existing.balance = spec["balance"]
+                    existing.apr = spec["apr"]
+                    existing.minimum_payment = spec["minimum_payment"]
+                    existing.due_day = spec["due_day"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the demo seed placeholder with idempotent inserts for categories, transactions, habits, and liabilities
- ensure seeded transactions are linked to a demo checking account for completeness
- document how to execute the demo seed script and explain its upsert guarantees in the README

## Testing
- pytest tests/test_admin_jobs.py *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68f862c272dc83219e9dea8d38f5d05f