### PR TITLE
Document packaging flow and guard spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ lint:
 
 
 package:
-        @if [ ! -f PocketSage.spec ]; then \
-                echo "PocketSage.spec is missing. Restore it from version control or regenerate with 'pyinstaller run.py --name PocketSage --specpath .'"; \
-                exit 1; \
-        fi
-        pyinstaller PocketSage.spec --clean
-        # TODO(@release): customize spec and add post-build smoke test.
+	@if [ ! -f PocketSage.spec ]; then \
+		echo "PocketSage.spec is missing. Restore it from version control or regenerate with 'pyinstaller run.py --name PocketSage --specpath .'"; \
+		exit 1; \
+	fi
+	pyinstaller PocketSage.spec --clean
+	# TODO(@release): customize spec and add post-build smoke test.
 
 demo-seed:
 	$(PYTHON) scripts/seed_demo.py

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,12 @@ lint:
 
 
 package:
-	pyinstaller PocketSage.spec --clean
-	# TODO(@release): customize spec and add post-build smoke test.
+        @if [ ! -f PocketSage.spec ]; then \
+                echo "PocketSage.spec is missing. Restore it from version control or regenerate with 'pyinstaller run.py --name PocketSage --specpath .'"; \
+                exit 1; \
+        fi
+        pyinstaller PocketSage.spec --clean
+        # TODO(@release): customize spec and add post-build smoke test.
 
 demo-seed:
 	$(PYTHON) scripts/seed_demo.py

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Framework Owner checkpoint for the PocketSage desktop-first Flask app. Focus are
 - `make dev` → run Flask dev server
 - `make test` → pytest (currently skipped TODOs)
 - `make lint` → ruff + black check
-- `make package` → PyInstaller stub build
+- `make package` → runs `pyinstaller PocketSage.spec --clean`
 - `make demo-seed` → placeholder seeding script (raises TODO)
 
 ## Configuration Flags

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,12 @@
 
 ## Packaging
 - PyInstaller spec (`PocketSage.spec`) bundles CLI app, templates, and static assets.
-- Makefile `package` target runs PyInstaller (TODO: refine hidden imports & bundling).
+- `make package` runs `pyinstaller PocketSage.spec --clean` (TODO: refine hidden imports & bundling).
+
+### Packaging checklist
+- [ ] Confirm `PocketSage.spec` exists at the repository root before packaging.
+  - If the file is missing, restore it from version control or regenerate with `pyinstaller run.py --name PocketSage --specpath .`.
+- [ ] Run `make package` to build the binary with PyInstaller.
 
 ## TODO Highlights
 - Replace repository protocols with SQLModel implementations.


### PR DESCRIPTION
## Summary
- clarify that `make package` invokes `pyinstaller PocketSage.spec --clean` in the README and architecture guide
- add a packaging checklist entry describing how to recover a missing PyInstaller spec
- update the Makefile `package` target to exit early when the spec file is absent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f862c59e38832193edc67ed4c93510