### PR TITLE
Automate template data discovery for packaging

### DIFF
--- a/PocketSage.spec
+++ b/PocketSage.spec
@@ -1,22 +1,74 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-import os
+import importlib
+import sys
 from pathlib import Path
 
 block_cipher = None
 
 project_root = Path(__file__).resolve().parent if "__file__" in globals() else Path.cwd()
 
+sys.path.insert(0, str(project_root))
+
 pocketsage_pkg = project_root / "pocketsage"
 
-data_files = [
-    (str(pocketsage_pkg / "templates"), "pocketsage/templates"),
-    (str(pocketsage_pkg / "static"), "pocketsage/static"),
+blueprint_modules = [
+    "pocketsage.blueprints.admin",
+    "pocketsage.blueprints.habits",
+    "pocketsage.blueprints.home",
+    "pocketsage.blueprints.ledger",
+    "pocketsage.blueprints.liabilities",
+    "pocketsage.blueprints.portfolio",
 ]
+
+
+def iter_blueprint_template_dirs(modules: list[str]):
+    """Yield (source, destination) tuples for blueprint template folders."""
+
+    seen = set()
+    for module_name in modules:
+        module = importlib.import_module(module_name)
+        blueprint = getattr(module, "bp", None)
+        template_folder = getattr(blueprint, "template_folder", None) if blueprint else None
+        if not template_folder:
+            continue
+
+        template_dir = (Path(blueprint.root_path) / template_folder).resolve()
+        if not template_dir.is_dir() or template_dir in seen:
+            continue
+
+        seen.add(template_dir)
+        try:
+            rel_dest = template_dir.relative_to(pocketsage_pkg)
+        except ValueError:
+            continue
+
+        yield (str(template_dir), f"pocketsage/{rel_dest.as_posix()}")
+
+
+shared_template_files = sorted(
+    path
+    for path in (pocketsage_pkg / "templates").iterdir()
+    if path.is_file()
+)
+
+
+data_files = [
+    *sorted(iter_blueprint_template_dirs(blueprint_modules), key=lambda entry: entry[1]),
+    *(
+        (str(path), f"pocketsage/templates/{path.name}")
+        for path in shared_template_files
+    ),
+]
+
+static_dir = pocketsage_pkg / "static"
+if static_dir.is_dir():
+    data_files.append((str(static_dir), "pocketsage/static"))
 
 hidden_imports = [
     "pocketsage.blueprints.admin",
     "pocketsage.blueprints.habits",
+    "pocketsage.blueprints.home",
     "pocketsage.blueprints.ledger",
     "pocketsage.blueprints.liabilities",
     "pocketsage.blueprints.portfolio",

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,22 @@
+# PocketSage Packaging Guide
+
+## PyInstaller data files
+
+PyInstaller bundles HTML templates and static assets so the packaged
+application can render blueprints without accessing the source tree. The
+`PocketSage.spec` file automatically gathers the template directories from
+registered blueprints:
+
+- `pocketsage/templates/admin`
+- `pocketsage/templates/habits`
+- `pocketsage/templates/home`
+- `pocketsage/templates/ledger`
+- `pocketsage/templates/liabilities`
+- `pocketsage/templates/portfolio`
+
+Shared layout files such as `_flash.html`, `_nav.html`, and `base.html`
+are included individually from the `pocketsage/templates/` root directory.
+
+Static assets are copied via the `pocketsage/static/` directory. Add new
+blueprints to both the Flask app and `blueprint_modules` list inside
+`PocketSage.spec` so their templates are bundled during packaging.


### PR DESCRIPTION
## Summary
- gather blueprint template directories dynamically in the PyInstaller spec
- include shared template files and static assets in the packaged data
- document the bundled template and static directories in the packaging guide

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f862c606c4832189eb1c780a4704af