### PR TITLE
Document PyInstaller entry parity and binary usage

### DIFF
--- a/PocketSage.spec
+++ b/PocketSage.spec
@@ -7,6 +7,9 @@ block_cipher = None
 
 project_root = Path(__file__).resolve().parent if "__file__" in globals() else Path.cwd()
 
+# Mirror the local runner entry point used by `python run.py`.
+entry_script = project_root / "run.py"
+
 pocketsage_pkg = project_root / "pocketsage"
 
 data_files = [
@@ -23,7 +26,7 @@ hidden_imports = [
 ]
 
 analysis = Analysis(
-    [str(project_root / "run.py")],
+    [str(entry_script)],
     pathex=[str(project_root)],
     binaries=[],
     datas=data_files,

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Framework Owner checkpoint for the PocketSage desktop-first Flask app. Focus are
 4. `python run.py`
 5. Visit http://127.0.0.1:5000 to view the landing page and navigate to scaffolded blueprints
 
+## Packaging
+- The PyInstaller build mirrors `run.py`, which calls `create_app()` and then `app.run(debug=True)` for a development-friendly binary entry point.
+- `make package` → run PyInstaller using `PocketSage.spec` (outputs to `dist/`).
+- Launch the bundled app the same way as the script (`./dist/PocketSage/PocketSage` on macOS/Linux, `dist\\PocketSage\\PocketSage.exe` on Windows) to confirm parity with local execution.
+
 ### Make Targets
 - `make setup` → install deps, enable pre-commit
 - `make dev` → run Flask dev server

--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -8,6 +8,7 @@
 ## Suggested Narrative
 1. **App Launch**
    - Run `make dev` (Windows: `python run.py`).
+   - To showcase the packaged build, first run `make package`, then execute the binary from `dist/PocketSage/` (`./PocketSage` on macOS/Linux or `PocketSage.exe` on Windows) which mirrors the `run.py` entry point.
    - Mention offline-first architecture and SQLCipher toggle.
 2. **Ledger Tour**
    - Show placeholder ledger list; describe upcoming rollups and Matplotlib charts.

--- a/docs/system_overview.md
+++ b/docs/system_overview.md
@@ -22,7 +22,7 @@ The sections below describe each component in more detail.
 | File | Purpose |
 | --- | --- |
 | `run.py` | Small runner that imports `create_app` and starts Flask's development server. |
-| `PocketSage.spec` | PyInstaller specification wiring the CLI entry point and extra data to build a desktop binary. |
+| `PocketSage.spec` | PyInstaller specification that bundles `run.py` (calls `create_app()` then `app.run(debug=True)`) and the extra data needed for a desktop binary. |
 | `Makefile` | Convenience shortcuts for linting, testing, packaging, and cleanup. |
 
 `run.py` delegates all setup to the application factory, ensuring configuration and blueprints stay consistent between development, production, and bundled binaries.


### PR DESCRIPTION
## Summary
- document that the packaged binary mirrors the run.py create_app/app.run pattern
- refresh README packaging section and demo runbook with binary launch guidance
- note the run.py entry coupling inside the PyInstaller spec for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f862c6c7b08321840cfd0271285721