### PR TITLE
feat: show recent exports in admin dashboard

### DIFF
--- a/pocketsage/blueprints/admin/routes.py
+++ b/pocketsage/blueprints/admin/routes.py
@@ -38,27 +38,33 @@ def _resolve_exports_dir() -> Path:
     return Path(current_app.instance_path) / "exports"
 
 
-def _latest_export_metadata(exports_dir: Path) -> Optional[dict]:
+def _recent_exports_metadata(exports_dir: Path, *, limit: int = 5) -> list[dict]:
     if not exports_dir.exists():
-        return None
+        return []
 
     archives = sorted(
         exports_dir.glob("pocketsage_export_*.zip"),
         key=lambda file: file.stat().st_mtime,
         reverse=True,
     )
-    if not archives:
-        return None
+    exports: list[dict] = []
+    for archive in archives[:limit]:
+        stat = archive.stat()
+        exports.append(
+            {
+                "name": archive.name,
+                "path": str(archive),
+                "modified_at": datetime.fromtimestamp(
+                    stat.st_mtime, tz=timezone.utc
+                ).isoformat(),
+                "size": stat.st_size,
+                "download_url": url_for(
+                    "admin.export_download", filename=archive.name
+                ),
+            }
+        )
 
-    latest = archives[0]
-    stat = latest.stat()
-    return {
-        "name": latest.name,
-        "path": str(latest),
-        "modified_at": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
-        "size": stat.st_size,
-        "download_url": url_for("admin.export_download"),
-    }
+    return exports
 
 
 @bp.get("/")
@@ -77,12 +83,14 @@ def dashboard():
     last_tx_time = last_tx.occurred_at.isoformat() if last_tx is not None else None
 
     exports_dir = _resolve_exports_dir()
-    latest_export = _latest_export_metadata(exports_dir)
+    recent_exports = _recent_exports_metadata(exports_dir)
+    latest_export = recent_exports[0] if recent_exports else None
 
     return render_template(
         "admin/index.html",
         stats={"transactions": tx_count, "last_transaction": last_tx_time},
         latest_export=latest_export,
+        exports=recent_exports,
         jobs=list_jobs(limit=10),
         exports_available=latest_export is not None,
     )
@@ -134,7 +142,7 @@ def export_reports():
 
 @bp.get("/export/download")
 def export_download():
-    """Download the most recent export ZIP from the instance exports folder."""
+    """Download an export ZIP from the instance exports folder."""
     exports_dir = _resolve_exports_dir()
     if not exports_dir.exists():
         flash("No exports available", "warning")
@@ -148,8 +156,24 @@ def export_download():
         flash("No exports available", "warning")
         return redirect(url_for("admin.dashboard"))
 
-    latest = zips[0]
-    return send_file(latest, as_attachment=True)
+    requested_name = request.args.get("filename")
+    selected_path = zips[0]
+    if requested_name:
+        exports_root = exports_dir.resolve()
+        candidate = (exports_dir / requested_name).resolve(strict=False)
+        if (
+            candidate.exists()
+            and candidate.is_file()
+            and candidate.suffix == ".zip"
+            and candidate.parent == exports_root
+            and candidate.name.startswith("pocketsage_export_")
+        ):
+            selected_path = candidate
+        else:
+            flash("Requested export not found", "warning")
+            return redirect(url_for("admin.dashboard"))
+
+    return send_file(selected_path, as_attachment=True)
 
 
 @bp.get("/jobs/<job_id>")

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -98,6 +98,54 @@ body {
     flex-wrap: wrap;
 }
 
+.exports-table-wrapper {
+    margin-top: 1rem;
+    overflow-x: auto;
+}
+
+.exports-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 24rem;
+    font-size: 0.95rem;
+}
+
+.exports-table th,
+.exports-table td {
+    text-align: left;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.exports-table thead th {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.exports-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.exports-table tbody tr:hover {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.exports-table code {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 0.35rem;
+    padding: 0.125rem 0.35rem;
+}
+
+.exports-actions,
+.exports-action-cell {
+    white-space: nowrap;
+    text-align: right;
+}
+
+.exports-empty {
+    margin: 0.5rem 0 0;
+}
+
 .btn-primary,
 .btn-secondary,
 .btn-link {

--- a/pocketsage/templates/admin/index.html
+++ b/pocketsage/templates/admin/index.html
@@ -48,15 +48,37 @@
 
     <section class="admin-panel">
       <h2>Exports</h2>
-      {% if latest_export %}
-        <p class="export-meta">
-          Latest export <code>{{ latest_export.name }}</code>
-          (<span title="{{ latest_export.size }} bytes">{{ latest_export.size | filesizeformat }}</span>)
-          generated <time datetime="{{ latest_export.modified_at }}">{{ latest_export.modified_at }}</time>.
-        </p>
-        <a class="btn-link" href="{{ latest_export.download_url }}">Download Latest Export</a>
+      {% if exports %}
+        <div class="exports-table-wrapper">
+          <table class="exports-table">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Generated</th>
+                <th scope="col">Size</th>
+                <th scope="col" class="exports-actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for export in exports %}
+                <tr>
+                  <td data-label="Name"><code>{{ export.name }}</code></td>
+                  <td data-label="Generated">
+                    <time datetime="{{ export.modified_at }}">{{ export.modified_at }}</time>
+                  </td>
+                  <td data-label="Size">
+                    <span title="{{ export.size }} bytes">{{ export.size | filesizeformat }}</span>
+                  </td>
+                  <td data-label="Actions" class="exports-action-cell">
+                    <a class="btn-link" href="{{ export.download_url }}">Download</a>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       {% else %}
-        <p class="empty">No exports generated yet.</p>
+        <p class="empty exports-empty">No exports generated yet.</p>
       {% endif %}
     </section>
 


### PR DESCRIPTION
## Summary
- provide recent export metadata from the admin routes and allow selecting a bundle to download
- render a table of recent export bundles with size, generated time, and download links on the admin dashboard
- add responsive styling for the new exports table and empty state

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68f862d12fa88321a202bbc52ad27575