### PR TITLE
Document CLI operations in ops runbook

### DIFF
--- a/docs/ops_runbook.md
+++ b/docs/ops_runbook.md
@@ -1,0 +1,19 @@
+# Operations Checklist & Runbook
+
+## CLI Commands
+
+### Seed Demo Data
+- **Command:** `flask pocketsage-seed --demo`
+- **Purpose:** Seeds demo transactions by invoking `pocketsage.blueprints.admin.tasks.run_demo_seed` when the database is empty.
+- **Expected Output:**
+  - `Scheduling demo seed...`
+  - `Demo seed completed (or scheduled).`
+- **Side Effects:** Triggers the demo seed workflow and schedules/executes the insert of sample transactions (safe no-op if data already exists).
+
+### Export Artifacts
+- **Command:** `flask pocketsage-export`
+- **Purpose:** Calls `pocketsage.blueprints.admin.tasks.run_export` to build the export archive containing CSV and PNG artifacts.
+- **Expected Output:**
+  - `Starting export...`
+  - `Export written: <path>`
+- **Side Effects:** Creates a ZIP archive in the current working directory (unless an output directory is provided via the task) and prints the filesystem path to the generated file.


### PR DESCRIPTION
## Summary
- add an operations runbook section that documents the `pocketsage-seed --demo` and `pocketsage-export` Flask CLI commands
- capture the expected output strings and side effects (demo seed scheduling and export archive path)

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f862b1fc3c8321b1de35dfbe2b00f9