### PR TITLE
Add portfolio sorting and filtering UI

### DIFF
--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -238,6 +238,44 @@ body {
     text-align: right;
 }
 
+.portfolio-controls {
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+}
+
+.filter-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    gap: 0.75rem;
+}
+
+.filter-field {
+    display: grid;
+    gap: 0.35rem;
+    font-size: 0.9rem;
+}
+
+.filter-field input[type="search"] {
+    background: rgba(15, 23, 42, 0.35);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 0.5rem;
+    padding: 0.6rem 0.75rem;
+    color: inherit;
+}
+
+.filter-field input[type="search"]:focus {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
+}
+
+.filter-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
 .table-scroll {
     overflow-x: auto;
     border-radius: 0.5rem;
@@ -262,6 +300,102 @@ body {
 
 .holdings-table td[data-label] {
     font-variant-numeric: tabular-nums;
+}
+
+.holdings-table th {
+    white-space: nowrap;
+}
+
+.sort-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: inherit;
+    text-decoration: none;
+}
+
+.sort-link:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
+    border-radius: 0.35rem;
+}
+
+.sort-link .sort-label {
+    font-weight: 600;
+}
+
+.sort-link.is-active {
+    color: #22d3ee;
+}
+
+.sort-indicator {
+    display: inline-flex;
+    position: relative;
+    width: 0.75rem;
+    height: 0.95rem;
+}
+
+.sort-indicator::before,
+.sort-indicator::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    border-left: 0.3rem solid transparent;
+    border-right: 0.3rem solid transparent;
+    transition: border-color 0.2s ease;
+}
+
+.sort-indicator::before {
+    top: 0;
+    border-bottom: 0.45rem solid rgba(148, 163, 184, 0.6);
+}
+
+.sort-indicator::after {
+    bottom: 0;
+    border-top: 0.45rem solid rgba(148, 163, 184, 0.6);
+}
+
+.sort-link[data-active-direction="asc"] .sort-indicator::before {
+    border-bottom-color: #22d3ee;
+}
+
+.sort-link[data-active-direction="asc"] .sort-indicator::after {
+    border-top-color: rgba(148, 163, 184, 0.3);
+}
+
+.sort-link[data-active-direction="desc"] .sort-indicator::after {
+    border-top-color: #22d3ee;
+}
+
+.sort-link[data-active-direction="desc"] .sort-indicator::before {
+    border-bottom-color: rgba(148, 163, 184, 0.3);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 50rem) {
+    .portfolio-controls {
+        gap: 0.75rem;
+    }
+
+    .filter-actions {
+        justify-content: flex-start;
+    }
+
+    .holdings-table {
+        min-width: 32rem;
+    }
 }
 
 .upload-card {

--- a/pocketsage/templates/portfolio/index.html
+++ b/pocketsage/templates/portfolio/index.html
@@ -39,35 +39,68 @@
 
     <section class="portfolio-holdings" aria-label="Holdings table">
       <h2>Holdings</h2>
+      {% set filters_active = filters_state.symbol or filters_state.account or filters_state.currency %}
+      {% if sort_options %}
+        <form class="portfolio-controls" method="get" aria-label="Filter holdings">
+          <input type="hidden" name="sort" value="{{ sort_column }}">
+          <input type="hidden" name="direction" value="{{ sort_direction }}">
+          <div class="filter-group">
+            <label class="filter-field">
+              <span>Symbol</span>
+              <input type="search" name="symbol" value="{{ filters_state.symbol }}" placeholder="e.g. AAPL" autocomplete="off">
+            </label>
+            <label class="filter-field">
+              <span>Account</span>
+              <input type="search" name="account" value="{{ filters_state.account }}" placeholder="Brokerage" autocomplete="off">
+            </label>
+            <label class="filter-field">
+              <span>Currency</span>
+              <input type="search" name="currency" value="{{ filters_state.currency }}" placeholder="USD" autocomplete="off">
+            </label>
+          </div>
+          <div class="filter-actions">
+            <button type="submit" class="btn-secondary">Apply filters</button>
+            {% if filters_active %}
+              <a class="btn-link" href="{{ url_for('portfolio.list_portfolio') }}">Clear</a>
+            {% endif %}
+          </div>
+        </form>
+      {% endif %}
       {% if holdings %}
         <div class="table-scroll">
           <table class="holdings-table" role="grid">
             <thead>
               <tr>
-                <th scope="col">Symbol</th>
-                <th scope="col">Quantity</th>
-                <th scope="col">Average price</th>
-                <th scope="col">Market value</th>
-                <th scope="col">Allocation</th>
-                <th scope="col">Account</th>
-                <th scope="col">Currency</th>
+                {% for option in sort_options %}
+                  <th scope="col" aria-sort="{{ 'ascending' if option.active and sort_direction == 'asc' else 'descending' if option.active else 'none' }}">
+                    <a class="sort-link{% if option.active %} is-active{% endif %}" href="{{ option.url }}" data-sort="{{ option.id }}" data-next-direction="{{ option.next_direction }}" data-sort-type="{{ option.type }}" data-active-direction="{{ option.direction }}">
+                      <span class="sort-label">{{ option.label }}</span>
+                      <span class="sort-indicator" aria-hidden="true"></span>
+                      {% if option.active %}
+                        <span class="sr-only">Sorted {{ 'ascending' if sort_direction == 'asc' else 'descending' }}</span>
+                      {% endif %}
+                    </a>
+                  </th>
+                {% endfor %}
               </tr>
             </thead>
             <tbody>
               {% for holding in holdings %}
                 <tr>
-                  <td data-label="Symbol">{{ holding.symbol }}</td>
-                  <td data-label="Quantity">{{ holding.quantity_display }}</td>
-                  <td data-label="Average price">{{ holding.avg_price_display }}</td>
-                  <td data-label="Market value">{{ holding.value_display }}</td>
-                  <td data-label="Allocation">{{ holding.allocation_display }}</td>
-                  <td data-label="Account">{{ holding.account or "—" }}</td>
-                  <td data-label="Currency">{{ holding.currency }}</td>
+                  <td data-label="Symbol" data-sort-value="{{ holding.symbol }}">{{ holding.symbol }}</td>
+                  <td data-label="Quantity" data-sort-value="{{ holding.quantity }}">{{ holding.quantity_display }}</td>
+                  <td data-label="Average price" data-sort-value="{{ holding.avg_price }}">{{ holding.avg_price_display }}</td>
+                  <td data-label="Market value" data-sort-value="{{ holding.value }}">{{ holding.value_display }}</td>
+                  <td data-label="Allocation" data-sort-value="{{ holding.allocation_pct }}">{{ holding.allocation_display }}</td>
+                  <td data-label="Account" data-sort-value="{{ holding.account or '' }}">{{ holding.account or "—" }}</td>
+                  <td data-label="Currency" data-sort-value="{{ holding.currency }}">{{ holding.currency }}</td>
                 </tr>
               {% endfor %}
             </tbody>
           </table>
         </div>
+      {% elif filters_active %}
+        <p class="empty">No holdings match your filters. Try adjusting or clearing them.</p>
       {% else %}
         <p class="empty">No holdings yet. Upload a CSV to see your portfolio here.</p>
       {% endif %}


### PR DESCRIPTION
## Summary
- add server-side sorting and filtering to the portfolio holdings endpoint
- expose accessible filter controls and sortable table headers in the portfolio template
- style the new controls, show sort indicators, and add client-side sorting for instant feedback

## Testing
- pytest tests/test_import_and_portfolio.py *(fails: missing Flask dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f862d37d28832185f44c4a6f59418a