### PR TITLE
Create liabilities form layout with defaults and validation

### DIFF
--- a/pocketsage/blueprints/liabilities/forms.py
+++ b/pocketsage/blueprints/liabilities/forms.py
@@ -1,22 +1,97 @@
-"""Liability form stubs."""
+"""Liability form definitions and validation helpers."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from decimal import Decimal
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Dict, Iterable, List
+
+
+StrategyChoices = Dict[str, str]
+
+
+DEFAULT_STRATEGIES: StrategyChoices = {
+    "avalanche": "Avalanche · prioritize highest APR first",
+    "snowball": "Snowball · knock out the smallest balance",
+    "hybrid": "Hybrid · mix avalanche with manual targeting",
+}
 
 
 @dataclass(slots=True)
 class LiabilityForm:
-    """Placeholder for liability creation/editing form."""
+    """Represents liability inputs and associated validation errors."""
 
     name: str = ""
-    balance: Decimal | None = None
-    apr: Decimal | None = None
-    minimum_payment: Decimal | None = None
+    balance: Decimal | str | None = None
+    apr: Decimal | str | None = None
+    minimum_payment: Decimal | str | None = None
+    target_strategy: str = "avalanche"
+    errors: Dict[str, List[str]] = field(default_factory=dict, init=False)
 
-    def validate(self) -> bool:
-        """Validate liability inputs."""
+    def validate(self, *, strategies: StrategyChoices | None = None) -> bool:
+        """Validate liability inputs returning True when all values are acceptable."""
 
-        # TODO(@debts-squad): enforce APR/balance/minimum payment ranges and units.
-        raise NotImplementedError
+        self.errors.clear()
+
+        if not self.name or not self.name.strip():
+            self.errors.setdefault("name", []).append("Enter the creditor or account name.")
+        else:
+            self.name = self.name.strip()
+
+        strategies = strategies or DEFAULT_STRATEGIES
+
+        self.balance = self._parse_currency("balance", self.balance, minimum=Decimal("0.01"))
+        self.apr = self._parse_currency("apr", self.apr, minimum=Decimal("0"))
+        self.minimum_payment = self._parse_currency(
+            "minimum_payment", self.minimum_payment, minimum=Decimal("0.01")
+        )
+
+        if isinstance(self.apr, Decimal) and (self.apr < 0 or self.apr > Decimal("100")):
+            self.errors.setdefault("apr", []).append("APR must be between 0 and 100 percent.")
+
+        if isinstance(self.minimum_payment, Decimal) and isinstance(self.balance, Decimal):
+            if self.minimum_payment > self.balance:
+                self.errors.setdefault("minimum_payment", []).append(
+                    "Minimum payment cannot be greater than the balance."
+                )
+
+        if not self.target_strategy or self.target_strategy not in strategies:
+            self.errors.setdefault("target_strategy", []).append("Choose a payoff strategy.")
+
+        return not self.errors
+
+    def _parse_currency(
+        self,
+        field: str,
+        value: Decimal | str | None,
+        *,
+        minimum: Decimal,
+    ) -> Decimal | None:
+        """Parse and validate numeric input, storing errors when parsing fails."""
+
+        if value is None or value == "":
+            self.errors.setdefault(field, []).append("This field is required.")
+            return None
+
+        if not isinstance(value, Decimal):
+            try:
+                value = Decimal(str(value))
+            except (InvalidOperation, TypeError, ValueError):
+                self.errors.setdefault(field, []).append("Enter a valid number.")
+                return None
+
+        if value < minimum:
+            message = (
+                "Amount must be greater than zero."
+                if minimum > 0
+                else "Amount must be at least zero."
+            )
+            self.errors.setdefault(field, []).append(message)
+        return value
+
+    @property
+    def error_messages(self) -> Iterable[str]:
+        """Flattened iterable of error strings for summaries."""
+
+        for messages in self.errors.values():
+            yield from messages

--- a/pocketsage/blueprints/liabilities/routes.py
+++ b/pocketsage/blueprints/liabilities/routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from flask import flash, redirect, render_template, url_for
+from flask import flash, redirect, render_template, request, url_for
 
 from . import bp
 from .forms import DEFAULT_STRATEGIES, LiabilityForm
@@ -42,4 +42,31 @@ def new_liability():
         "liabilities/form.html",
         form=form,
         strategy_choices=DEFAULT_STRATEGIES,
+    )
+
+
+@bp.post("/new")
+def create_liability():
+    """Validate liability payload and queue persistence."""
+
+    form = LiabilityForm(
+        name=request.form.get("name", ""),
+        balance=request.form.get("balance"),
+        apr=request.form.get("apr"),
+        minimum_payment=request.form.get("minimum_payment"),
+        target_strategy=request.form.get("target_strategy", ""),
+    )
+
+    if form.validate(strategies=DEFAULT_STRATEGIES):
+        # TODO(@debts-squad): persist liability using repository and kickoff payoff plan.
+        flash("Liability saved! We'll crunch the payoff plan next.", "success")
+        return redirect(url_for("liabilities.list_liabilities"))
+
+    return (
+        render_template(
+            "liabilities/form.html",
+            form=form,
+            strategy_choices=DEFAULT_STRATEGIES,
+        ),
+        400,
     )

--- a/pocketsage/blueprints/liabilities/routes.py
+++ b/pocketsage/blueprints/liabilities/routes.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 from flask import flash, redirect, render_template, url_for
 
 from . import bp
+from .forms import DEFAULT_STRATEGIES, LiabilityForm
 
 
 @bp.get("/")
@@ -28,5 +31,15 @@ def recalc_liability(liability_id: int):
 def new_liability():
     """Render creation form for a liability."""
 
-    # TODO(@debts-squad): supply LiabilityForm defaults via forms module.
-    return render_template("liabilities/form.html")
+    form = LiabilityForm(
+        name="Capital One Venture",
+        balance=Decimal("6240.18"),
+        apr=Decimal("23.99"),
+        minimum_payment=Decimal("160.00"),
+        target_strategy="avalanche",
+    )
+    return render_template(
+        "liabilities/form.html",
+        form=form,
+        strategy_choices=DEFAULT_STRATEGIES,
+    )

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -388,4 +388,146 @@ body {
     flex-wrap: wrap;
 }
 
+.form-card {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1.75rem;
+    display: grid;
+    gap: 1.5rem;
+    max-width: 48rem;
+}
+
+.form-header h1 {
+    margin: 0;
+}
+
+.form-header p {
+    margin: 0.35rem 0 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.form-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.form-row {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+
+.form-field {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.form-field label {
+    font-weight: 600;
+}
+
+.form-control {
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 0.65rem;
+    background: rgba(15, 23, 42, 0.45);
+    color: inherit;
+    padding: 0.75rem 1rem;
+    font: inherit;
+}
+
+.form-control:focus {
+    outline: 2px solid rgba(56, 189, 248, 0.65);
+    outline-offset: 1px;
+    border-color: rgba(56, 189, 248, 0.85);
+}
+
+.form-control-prefix,
+.form-control-suffix {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.form-control-prefix .form-control,
+.form-control-suffix .form-control {
+    width: 100%;
+    padding-left: 2.25rem;
+}
+
+.form-control-suffix .form-control {
+    padding-left: 1rem;
+    padding-right: 2.25rem;
+}
+
+.form-control-prefix .prefix,
+.form-control-suffix .suffix {
+    position: absolute;
+    left: 0.85rem;
+    font-weight: 600;
+    opacity: 0.7;
+}
+
+.form-control-suffix .suffix {
+    left: auto;
+    right: 0.85rem;
+}
+
+.form-hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.field-error {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #f97316;
+}
+
+.has-error .form-control {
+    border-color: rgba(249, 115, 22, 0.85);
+    box-shadow: 0 0 0 1px rgba(249, 115, 22, 0.55);
+}
+
+.has-error label {
+    color: #f97316;
+}
+
+.form-errors {
+    border: 1px solid rgba(249, 115, 22, 0.35);
+    background: rgba(249, 115, 22, 0.08);
+    color: #f97316;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+}
+
+.form-errors h2 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.form-errors ul {
+    margin: 0.75rem 0 0;
+    padding-left: 1.25rem;
+    display: grid;
+    gap: 0.35rem;
+}
+
+.form-errors a {
+    color: inherit;
+}
+
+.form-actions {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.form-actions .btn-link {
+    padding-left: 0;
+    padding-right: 0;
+}
+
 /* TODO(@ux-team): extend design tokens, typography scale, and dark/light mode palettes. */

--- a/pocketsage/templates/liabilities/form.html
+++ b/pocketsage/templates/liabilities/form.html
@@ -1,6 +1,147 @@
 {% extends 'base.html' %}
 {% block title %}New Liability · PocketSage{% endblock %}
 {% block content %}
-  <h1>Create Liability</h1>
-  <p class="todo">TODO(@debts-squad): build APR/minimum payment form with validation copy.</p>
+  <section class="form-card">
+    <header class="form-header">
+      <h1>Create Liability</h1>
+      <p>Capture the details we need to project payoff timelines and prioritize this debt.</p>
+    </header>
+
+    <form method="post" class="form-grid" novalidate>
+      {% if form.errors %}
+        <div class="form-errors" role="alert" aria-live="assertive">
+          <h2>We need a bit more information</h2>
+          <ul>
+            {% for field, messages in form.errors.items() %}
+              {% for message in messages %}
+                <li><a href="#{{ field }}">{{ message }}</a></li>
+              {% endfor %}
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      <div class="form-field{% if form.errors.name %} has-error{% endif %}">
+        <label for="name">Creditor name</label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          class="form-control"
+          value="{{ form.name | e }}"
+          autocomplete="organization"
+          aria-required="true"
+          aria-invalid="{{ 'true' if form.errors.name else 'false' }}"
+          aria-describedby="name-hint{% if form.errors.name %} name-error{% endif %}"
+        >
+        <p class="form-hint" id="name-hint">Examples: Capital One Venture, Great Lakes Student Loan</p>
+        {% if form.errors.name %}
+          <p class="field-error" id="name-error">{{ form.errors.name | join(' ') }}</p>
+        {% endif %}
+      </div>
+
+      <div class="form-row">
+        <div class="form-field{% if form.errors.balance %} has-error{% endif %}">
+          <label for="balance">Balance</label>
+          <div class="form-control-prefix">
+            <span class="prefix" aria-hidden="true">$</span>
+            <input
+              id="balance"
+              name="balance"
+              type="number"
+              step="0.01"
+              min="0"
+              class="form-control"
+              value="{{ form.balance if form.balance is not none else '' }}"
+              inputmode="decimal"
+              aria-required="true"
+              aria-invalid="{{ 'true' if form.errors.balance else 'false' }}"
+              aria-describedby="balance-hint{% if form.errors.balance %} balance-error{% endif %}"
+            >
+          </div>
+          <p class="form-hint" id="balance-hint">Current payoff amount including any accrued interest.</p>
+          {% if form.errors.balance %}
+            <p class="field-error" id="balance-error">{{ form.errors.balance | join(' ') }}</p>
+          {% endif %}
+        </div>
+
+        <div class="form-field{% if form.errors.apr %} has-error{% endif %}">
+          <label for="apr">APR</label>
+          <div class="form-control-suffix">
+            <input
+              id="apr"
+              name="apr"
+              type="number"
+              step="0.01"
+              min="0"
+              max="100"
+              class="form-control"
+              value="{{ form.apr if form.apr is not none else '' }}"
+              inputmode="decimal"
+              aria-required="true"
+              aria-invalid="{{ 'true' if form.errors.apr else 'false' }}"
+              aria-describedby="apr-hint{% if form.errors.apr %} apr-error{% endif %}"
+            >
+            <span class="suffix" aria-hidden="true">%</span>
+          </div>
+          <p class="form-hint" id="apr-hint">Annual percentage rate (0-100%).</p>
+          {% if form.errors.apr %}
+            <p class="field-error" id="apr-error">{{ form.errors.apr | join(' ') }}</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-field{% if form.errors.minimum_payment %} has-error{% endif %}">
+          <label for="minimum_payment">Minimum payment</label>
+          <div class="form-control-prefix">
+            <span class="prefix" aria-hidden="true">$</span>
+            <input
+              id="minimum_payment"
+              name="minimum_payment"
+              type="number"
+              step="0.01"
+              min="0"
+              class="form-control"
+              value="{{ form.minimum_payment if form.minimum_payment is not none else '' }}"
+              inputmode="decimal"
+              aria-required="true"
+              aria-invalid="{{ 'true' if form.errors.minimum_payment else 'false' }}"
+              aria-describedby="minimum_payment-hint{% if form.errors.minimum_payment %} minimum_payment-error{% endif %}"
+            >
+          </div>
+          <p class="form-hint" id="minimum_payment-hint">Required monthly payment amount.</p>
+          {% if form.errors.minimum_payment %}
+            <p class="field-error" id="minimum_payment-error">{{ form.errors.minimum_payment | join(' ') }}</p>
+          {% endif %}
+        </div>
+
+        <div class="form-field{% if form.errors.target_strategy %} has-error{% endif %}">
+          <label for="target_strategy">Target strategy</label>
+          <select
+            id="target_strategy"
+            name="target_strategy"
+            class="form-control"
+            aria-required="true"
+            aria-invalid="{{ 'true' if form.errors.target_strategy else 'false' }}"
+            aria-describedby="target_strategy-hint{% if form.errors.target_strategy %} target_strategy-error{% endif %}"
+          >
+            <option value="" disabled {% if not form.target_strategy %}selected{% endif %}>Select a payoff focus</option>
+            {% for value, label in strategy_choices.items() %}
+              <option value="{{ value }}" {% if form.target_strategy == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
+          <p class="form-hint" id="target_strategy-hint">Choose how PocketSage prioritizes this debt in the payoff roadmap.</p>
+          {% if form.errors.target_strategy %}
+            <p class="field-error" id="target_strategy-error">{{ form.errors.target_strategy | join(' ') }}</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <button type="submit" class="btn-primary">Save liability</button>
+        <a class="btn-link" href="{{ url_for('liabilities.list_liabilities') }}">Cancel</a>
+      </div>
+    </form>
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a richer LiabilityForm with default strategy choices and validation helpers
- pre-populate the new liability view with example data and strategy options
- replace the liabilities form template with structured fields and shared form styling

## Testing
- pytest *(fails: missing optional dependency `flask` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f862d641208321aaa493f030a53eb7