### PR TITLE
Add liabilities dashboard with payoff summaries

### DIFF
--- a/pocketsage/blueprints/liabilities/routes.py
+++ b/pocketsage/blueprints/liabilities/routes.py
@@ -2,17 +2,177 @@
 
 from __future__ import annotations
 
-from flask import flash, redirect, render_template, url_for
+from calendar import monthrange
+from dataclasses import dataclass
+from datetime import date
+from math import ceil
+from typing import Iterable
 
+from flask import flash, redirect, render_template, url_for
+from sqlmodel import select
+
+from ...extensions import session_scope
+from ...models.liability import Liability
 from . import bp
+
+
+@dataclass(slots=True)
+class LiabilityView:
+    """Presentation layer model for liabilities."""
+
+    id: int
+    name: str
+    balance: float
+    balance_display: str
+    apr_display: str
+    minimum_payment_display: str
+    strategy: str
+    strategy_display: str
+    next_due_date: date
+    next_due_display: str
+    is_overdue: bool
+    target_payoff_date: date | None
+    target_payoff_display: str
+    progress_pct: float
+    progress_display: str
+
+
+def _add_months(start: date, months: int) -> date:
+    month = start.month - 1 + months
+    year = start.year + month // 12
+    month = month % 12 + 1
+    day = min(start.day, monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def _estimate_payoff_date(balance: float, minimum_payment: float, *, base: date) -> date | None:
+    if minimum_payment <= 0:
+        return None
+    months = max(1, ceil(balance / minimum_payment))
+    return _add_months(base, months)
+
+
+def _progress_percentage(*, opened_on: date | None, target: date | None, today: date) -> float:
+    if opened_on is None or target is None:
+        return 0.0
+    total_days = (target - opened_on).days
+    if total_days <= 0:
+        return 100.0
+    elapsed_days = max(0, (today - opened_on).days)
+    progress = min(1.0, elapsed_days / total_days)
+    return round(progress * 100, 1)
+
+
+def _normalize_strategy(value: str | None) -> str:
+    if not value:
+        return "unspecified"
+    return value.strip().lower()
+
+
+def _hydrate_liabilities(liabilities: Iterable[Liability], *, today: date) -> tuple[list[LiabilityView], dict]:
+    rows: list[LiabilityView] = []
+    total_balance = 0.0
+    total_minimum_payment = 0.0
+    total_apr = 0.0
+    strategy_summary: dict[str, dict[str, float | int]] = {}
+    overdue_count = 0
+
+    for liability in liabilities:
+        balance = float(liability.balance or 0.0)
+        apr = float(liability.apr or 0.0)
+        minimum_payment = float(liability.minimum_payment or 0.0)
+        strategy = _normalize_strategy(liability.payoff_strategy)
+
+        current_month_due = date(today.year, today.month, liability.due_day)
+        is_overdue = current_month_due < today
+        if is_overdue:
+            overdue_count += 1
+            next_due = _add_months(current_month_due, 1)
+        else:
+            next_due = current_month_due
+
+        target_payoff = _estimate_payoff_date(balance, minimum_payment, base=today)
+        progress_pct = _progress_percentage(
+            opened_on=liability.opened_on,
+            target=target_payoff,
+            today=today,
+        )
+
+        rows.append(
+            LiabilityView(
+                id=liability.id or 0,
+                name=liability.name,
+                balance=balance,
+                balance_display=f"${balance:,.2f}",
+                apr_display=f"{apr:.2f}%",
+                minimum_payment_display=f"${minimum_payment:,.2f}",
+                strategy=strategy,
+                strategy_display=strategy.replace("_", " ").title(),
+                next_due_date=next_due,
+                next_due_display=next_due.strftime("%b %d, %Y"),
+                is_overdue=is_overdue,
+                target_payoff_date=target_payoff,
+                target_payoff_display=target_payoff.strftime("%b %d, %Y") if target_payoff else "—",
+                progress_pct=progress_pct,
+                progress_display=f"{progress_pct:.0f}%",
+            )
+        )
+
+        total_balance += balance
+        total_minimum_payment += minimum_payment
+        total_apr += apr
+
+        summary = strategy_summary.setdefault(
+            strategy,
+            {"count": 0, "balance": 0.0, "minimum_payment": 0.0},
+        )
+        summary["count"] = int(summary["count"]) + 1
+        summary["balance"] = float(summary["balance"]) + balance
+        summary["minimum_payment"] = float(summary["minimum_payment"]) + minimum_payment
+
+    average_apr = (total_apr / len(rows)) if rows else 0.0
+    summary_payload = {
+        "total_balance": total_balance,
+        "total_balance_display": f"${total_balance:,.2f}",
+        "total_minimum_payment": total_minimum_payment,
+        "total_minimum_payment_display": f"${total_minimum_payment:,.2f}",
+        "average_apr": average_apr,
+        "average_apr_display": f"{average_apr:.2f}%",
+        "overdue_count": overdue_count,
+        "strategies": [
+            {
+                "name": name,
+                "label": name.replace("_", " ").title(),
+                "count": data["count"],
+                "balance": data["balance"],
+                "balance_display": f"${float(data['balance']):,.2f}",
+                "minimum_payment": data["minimum_payment"],
+                "minimum_payment_display": f"${float(data['minimum_payment']):,.2f}",
+            }
+            for name, data in sorted(strategy_summary.items())
+        ],
+    }
+
+    rows.sort(key=lambda entry: entry.balance, reverse=True)
+    return rows, summary_payload
 
 
 @bp.get("/")
 def list_liabilities():
     """Display liabilities overview with payoff projections."""
 
-    # TODO(@debts-squad): hydrate context with repository data + payoff analytics.
-    return render_template("liabilities/index.html")
+    today = date.today()
+    with session_scope() as session:
+        liabilities = session.exec(select(Liability)).all()
+
+    liability_rows, summary = _hydrate_liabilities(liabilities, today=today)
+
+    return render_template(
+        "liabilities/index.html",
+        liabilities=liability_rows,
+        summary=summary,
+        today=today,
+    )
 
 
 @bp.post("/<int:liability_id>/recalculate")

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -388,4 +388,215 @@ body {
     flex-wrap: wrap;
 }
 
+.liabilities-dashboard {
+    display: grid;
+    gap: 2rem;
+}
+
+.liabilities-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.liabilities-subtitle {
+    margin: 0.25rem 0 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.liabilities-summary {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.summary-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.summary-card[data-state="warning"] {
+    border-color: rgba(248, 113, 113, 0.35);
+    background: rgba(248, 113, 113, 0.12);
+    color: #fecaca;
+}
+
+.summary-card h2 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.summary-value {
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-weight: 700;
+    margin: 0;
+}
+
+.liabilities-strategies {
+    display: grid;
+    gap: 1rem;
+}
+
+.liabilities-strategies h2 {
+    margin: 0;
+}
+
+.strategy-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+
+.strategy-card {
+    background: rgba(15, 23, 42, 0.45);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.strategy-card header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.strategy-card h3 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.strategy-count {
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.strategy-card dl {
+    display: grid;
+    gap: 0.5rem;
+    margin: 0;
+}
+
+.strategy-card dt {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: rgba(148, 163, 184, 0.85);
+}
+
+.strategy-card dd {
+    margin: 0.25rem 0 0;
+    font-size: 1rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.liabilities-table-card {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    display: grid;
+    gap: 1.25rem;
+}
+
+.liabilities-table-card header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.liabilities-table-card h2 {
+    margin: 0;
+}
+
+.table-hint {
+    margin: 0;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.liabilities-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 46rem;
+}
+
+.liabilities-table th,
+.liabilities-table td {
+    padding: 0.85rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+    font-variant-numeric: tabular-nums;
+}
+
+.liabilities-table th {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: rgba(148, 163, 184, 0.9);
+}
+
+.liabilities-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.liabilities-table tr.is-overdue {
+    background: rgba(248, 113, 113, 0.08);
+}
+
+.liabilities-table tr.is-overdue td,
+.liabilities-table tr.is-overdue th {
+    border-bottom-color: rgba(248, 113, 113, 0.2);
+}
+
+.liability-name {
+    font-weight: 600;
+}
+
+.strategy-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.2);
+    color: #bfdbfe;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.liability-progress {
+    position: relative;
+    height: 0.6rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.2);
+    overflow: hidden;
+}
+
+.liability-progress-bar {
+    position: absolute;
+    inset: 0;
+    width: var(--progress, 0%);
+    background: linear-gradient(90deg, #22d3ee, #3b82f6);
+    transition: width 0.4s ease;
+}
+
+.progress-value {
+    display: inline-block;
+    margin-top: 0.35rem;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
 /* TODO(@ux-team): extend design tokens, typography scale, and dark/light mode palettes. */

--- a/pocketsage/templates/liabilities/index.html
+++ b/pocketsage/templates/liabilities/index.html
@@ -1,6 +1,117 @@
 {% extends 'base.html' %}
 {% block title %}Liabilities · PocketSage{% endblock %}
 {% block content %}
-  <h1>Liabilities</h1>
-  <p class="todo">TODO(@debts-squad): visualize payoff strategies and payment schedules.</p>
+  <section class="liabilities-dashboard">
+    <header class="liabilities-header">
+      <div>
+        <h1>Liabilities</h1>
+        <p class="liabilities-subtitle">Track outstanding debts, monthly obligations, and payoff targets.</p>
+      </div>
+      <a class="btn-primary" href="{{ url_for('liabilities.new_liability') }}">Add liability</a>
+    </header>
+
+    <section class="liabilities-summary" aria-label="Liability totals">
+      <article class="summary-card">
+        <h2>Total Balance</h2>
+        <p class="summary-value">{{ summary.total_balance_display }}</p>
+      </article>
+      <article class="summary-card">
+        <h2>Monthly Minimums</h2>
+        <p class="summary-value">{{ summary.total_minimum_payment_display }}</p>
+      </article>
+      <article class="summary-card">
+        <h2>Average APR</h2>
+        <p class="summary-value">{{ summary.average_apr_display }}</p>
+      </article>
+      <article class="summary-card" data-state="warning">
+        <h2>Overdue This Month</h2>
+        <p class="summary-value">{{ summary.overdue_count }}</p>
+      </article>
+    </section>
+
+    {% if summary.strategies %}
+      <section class="liabilities-strategies" aria-label="Payoff strategy mix">
+        <h2>Payoff strategies</h2>
+        <div class="strategy-grid">
+          {% for strategy in summary.strategies %}
+            <article class="strategy-card">
+              <header>
+                <h3>{{ strategy.label }}</h3>
+                <span class="strategy-count">{{ strategy.count }} account{% if strategy.count != 1 %}s{% endif %}</span>
+              </header>
+              <dl>
+                <div>
+                  <dt>Balance</dt>
+                  <dd>{{ strategy.balance_display }}</dd>
+                </div>
+                <div>
+                  <dt>Minimum payments</dt>
+                  <dd>{{ strategy.minimum_payment_display }}</dd>
+                </div>
+              </dl>
+            </article>
+          {% endfor %}
+        </div>
+      </section>
+    {% endif %}
+
+    <section class="liabilities-table-card" aria-label="Liability details">
+      <header>
+        <h2>Liability detail</h2>
+        <p class="table-hint">Next due dates are based on the statement day and today&rsquo;s date ({{ today.strftime('%b %d, %Y') }}).</p>
+      </header>
+
+      {% if liabilities %}
+        <div class="table-scroll">
+          <table class="liabilities-table">
+            <thead>
+              <tr>
+                <th scope="col">Debt</th>
+                <th scope="col">Balance</th>
+                <th scope="col">APR</th>
+                <th scope="col">Minimum payment</th>
+                <th scope="col">Payoff strategy</th>
+                <th scope="col">Next due</th>
+                <th scope="col">Target payoff</th>
+                <th scope="col">Progress</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for liability in liabilities %}
+                <tr class="{% if liability.is_overdue %}is-overdue{% endif %}">
+                  <th scope="row">
+                    <div class="liability-name">{{ liability.name }}</div>
+                  </th>
+                  <td data-label="Balance">{{ liability.balance_display }}</td>
+                  <td data-label="APR">{{ liability.apr_display }}</td>
+                  <td data-label="Minimum">{{ liability.minimum_payment_display }}</td>
+                  <td data-label="Strategy">
+                    <span class="strategy-chip">{{ liability.strategy_display }}</span>
+                  </td>
+                  <td data-label="Next due">
+                    <time datetime="{{ liability.next_due_date.isoformat() }}">{{ liability.next_due_display }}</time>
+                  </td>
+                  <td data-label="Target payoff">
+                    {% if liability.target_payoff_date %}
+                      <time datetime="{{ liability.target_payoff_date.isoformat() }}">{{ liability.target_payoff_display }}</time>
+                    {% else %}
+                      <span class="empty">—</span>
+                    {% endif %}
+                  </td>
+                  <td data-label="Progress">
+                    <div class="liability-progress" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ liability.progress_pct }}" aria-label="{{ liability.name }} payoff progress">
+                      <div class="liability-progress-bar" style="--progress: {{ liability.progress_pct }}%"></div>
+                    </div>
+                    <span class="progress-value">{{ liability.progress_display }}</span>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="empty">No liabilities recorded yet. Add your first debt to see payoff timelines.</p>
+      {% endif %}
+    </section>
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load liabilities from the database and compute payoff estimates plus strategy breakdowns for the overview route
- replace the liabilities index template with a dashboard that lists debts, payoff targets, and progress meters
- style the liabilities views with summary cards, strategy chips, overdue highlighting, and progress bars

## Testing
- pytest pocketsage/tests/test_routes_smoke.py *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68f862d8cac88321883120828ae525be