### PR TITLE
Add empty state UI for habits overview

### DIFF
--- a/pocketsage/blueprints/habits/routes.py
+++ b/pocketsage/blueprints/habits/routes.py
@@ -14,7 +14,15 @@ def list_habits():
     """Show habits overview and current streaks."""
 
     # TODO(@habits-squad): populate context with repository results + streak calculations.
-    return render_template("habits/index.html")
+    habits: list = []
+
+    show_empty_state = len(habits) == 0
+
+    return render_template(
+        "habits/index.html",
+        habits=habits,
+        show_empty_state=show_empty_state,
+    )
 
 
 @bp.post("/<int:habit_id>/toggle")

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -147,6 +147,77 @@ body {
     font-style: italic;
 }
 
+.habits-page {
+    display: grid;
+    gap: 1.5rem;
+    max-width: 720px;
+}
+
+.habits-header h1 {
+    margin: 0;
+    font-size: clamp(2rem, 5vw, 2.75rem);
+}
+
+.empty-state-card {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 2rem;
+    display: grid;
+    gap: 1.75rem;
+    align-items: center;
+    text-align: left;
+}
+
+.empty-state-card svg {
+    width: clamp(160px, 40vw, 220px);
+    height: auto;
+    display: block;
+}
+
+.empty-state-illustration {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.empty-state-content {
+    display: grid;
+    gap: 1rem;
+}
+
+.empty-state-content h2 {
+    margin: 0;
+    font-size: clamp(1.5rem, 4vw, 2rem);
+}
+
+.empty-state-content p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.empty-state-benefits {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.35rem;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.empty-state-benefits strong {
+    color: #f8fafc;
+}
+
+.empty-state-card .btn-primary {
+    justify-self: start;
+}
+
+@media (min-width: 768px) {
+    .empty-state-card {
+        grid-template-columns: 1fr 1.1fr;
+    }
+}
+
 .job-list {
     list-style: none;
     margin: 0;

--- a/pocketsage/templates/habits/index.html
+++ b/pocketsage/templates/habits/index.html
@@ -1,6 +1,46 @@
 {% extends 'base.html' %}
 {% block title %}Habits · PocketSage{% endblock %}
 {% block content %}
-  <h1>Habits</h1>
-  <p class="todo">TODO(@habits-squad): render habits list with streak badges and toggle buttons.</p>
+  <section class="habits-page">
+    <header class="habits-header">
+      <h1>Habits</h1>
+    </header>
+
+    {% if show_empty_state %}
+      <section class="empty-state-card" aria-labelledby="habits-empty-title">
+        <div class="empty-state-illustration" aria-hidden="true">
+          <svg viewBox="0 0 160 160" role="img" focusable="false">
+            <defs>
+              <linearGradient id="emptyStateGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+                <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.95" />
+                <stop offset="100%" stop-color="#22c55e" stop-opacity="0.85" />
+              </linearGradient>
+            </defs>
+            <rect width="160" height="160" rx="24" fill="url(#emptyStateGradient)" opacity="0.25" />
+            <g stroke="#38bdf8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.85">
+              <path d="M44 88c12 18 28 28 48 28 10 0 18-3 24-8" />
+              <path d="M44 72l12-12 12 12 24-24 24 24" />
+            </g>
+            <circle cx="112" cy="52" r="12" fill="#22c55e" opacity="0.9" />
+            <path d="M108 52l4 4 8-8" stroke="#0f172a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+          </svg>
+        </div>
+        <div class="empty-state-content">
+          <h2 id="habits-empty-title">Track your progress, one habit at a time</h2>
+          <p>
+            Consistent routines compound into meaningful change. PocketSage highlights your streaks
+            so you can celebrate wins and stay motivated.
+          </p>
+          <ul class="empty-state-benefits">
+            <li><strong>Spot trends:</strong> review your daily check-ins to see momentum build.</li>
+            <li><strong>Stay accountable:</strong> streak reminders keep your commitments top of mind.</li>
+            <li><strong>Focus with intention:</strong> prioritize habits that align with your goals.</li>
+          </ul>
+          <a href="{{ url_for('habits.new_habit') }}" class="btn-primary">Create your first habit</a>
+        </div>
+      </section>
+    {% else %}
+      <p class="todo">TODO(@habits-squad): render habits list with streak badges and toggle buttons.</p>
+    {% endif %}
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- detect when the habits list is empty and pass a template flag
- render an illustrated empty state for the habits index with a call-to-action
- style the habits empty state to match the existing card aesthetic

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68f862dbd9a0832189963422a73a3b99