### PR TITLE
Add habit summaries and streak badges to habits dashboard

### DIFF
--- a/pocketsage/blueprints/habits/routes.py
+++ b/pocketsage/blueprints/habits/routes.py
@@ -18,8 +18,14 @@ def _compute_streak(entries: list[HabitEntry]) -> int:
     if not entries:
         return 0
 
+    today = date.today()
+    latest_entry = entries[0].occurred_on
+
+    if today - latest_entry > timedelta(days=1):
+        return 0
+
     streak = 1
-    previous_day = entries[0].occurred_on
+    previous_day = latest_entry
     for entry in entries[1:]:
         if entry.occurred_on == previous_day - timedelta(days=1):
             streak += 1

--- a/pocketsage/blueprints/habits/routes.py
+++ b/pocketsage/blueprints/habits/routes.py
@@ -2,19 +2,78 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
 from flask import flash, redirect, render_template, url_for
+from sqlmodel import select
 
 from . import bp
+from ...extensions import session_scope
+from ...models.habit import Habit, HabitEntry
+
+
+def _compute_streak(entries: list[HabitEntry]) -> int:
+    """Return the current streak length for the provided habit entries."""
+
+    if not entries:
+        return 0
+
+    streak = 1
+    previous_day = entries[0].occurred_on
+    for entry in entries[1:]:
+        if entry.occurred_on == previous_day - timedelta(days=1):
+            streak += 1
+            previous_day = entry.occurred_on
+        else:
+            break
+    return streak
 
 
 @bp.get("/")
 def list_habits():
     """Show habits overview and current streaks."""
 
-    # TODO(@habits-squad): populate context with repository results + streak calculations.
-    return render_template("habits/index.html")
+    with session_scope() as session:
+        result = session.exec(
+            select(Habit).where(Habit.is_active == True).order_by(Habit.name)  # noqa: E712
+        )
+        habits = result.all()
+
+        summaries: list[dict] = []
+        for habit in habits:
+            entries = session.exec(
+                select(HabitEntry)
+                .where(HabitEntry.habit_id == habit.id)
+                .order_by(HabitEntry.occurred_on.desc())
+            ).all()
+
+            last_completed = entries[0].occurred_on if entries else None
+            streak = _compute_streak(entries)
+            goal_text = habit.description.strip() or f"{habit.cadence.title()} habit"
+
+            streak_state = "muted"
+            if last_completed is not None:
+                if last_completed == date.today():
+                    streak_state = "success"
+                else:
+                    streak_state = "danger"
+
+            summaries.append(
+                {
+                    "id": habit.id,
+                    "name": habit.name,
+                    "goal": goal_text,
+                    "cadence": habit.cadence.title(),
+                    "streak": streak if entries else 0,
+                    "streak_state": streak_state,
+                    "last_completed": last_completed,
+                    "last_completed_display": (
+                        last_completed.strftime("%b %d, %Y") if last_completed else "—"
+                    ),
+                }
+            )
+
+    return render_template("habits/index.html", habits=summaries)
 
 
 @bp.post("/<int:habit_id>/toggle")

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -389,3 +389,106 @@ body {
 }
 
 /* TODO(@ux-team): extend design tokens, typography scale, and dark/light mode palettes. */
+
+.habits-dashboard {
+    display: grid;
+    gap: 1.75rem;
+}
+
+.habits-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.habits-subtitle {
+    margin: 0.35rem 0 0;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.habit-grid {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.habit-card {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-height: 100%;
+}
+
+.habit-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.habit-card h2 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.habit-goal {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.habit-meta {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.habit-meta div {
+    display: grid;
+    gap: 0.15rem;
+}
+
+.habit-meta dt {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.habit-meta dd {
+    margin: 0;
+    font-weight: 600;
+}
+
+.streak-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    background: rgba(148, 163, 184, 0.25);
+    color: #e2e8f0;
+}
+
+.streak-badge.is-success {
+    background: #065f46;
+    color: #6ee7b7;
+}
+
+.streak-badge.is-danger {
+    background: #7f1d1d;
+    color: #fca5a5;
+}
+
+.streak-badge.is-muted {
+    background: rgba(148, 163, 184, 0.25);
+    color: #cbd5f5;
+}

--- a/pocketsage/templates/habits/index.html
+++ b/pocketsage/templates/habits/index.html
@@ -1,6 +1,43 @@
 {% extends 'base.html' %}
 {% block title %}Habits · PocketSage{% endblock %}
 {% block content %}
-  <h1>Habits</h1>
-  <p class="todo">TODO(@habits-squad): render habits list with streak badges and toggle buttons.</p>
+  <section class="habits-dashboard">
+    <header class="habits-header">
+      <div>
+        <h1>Habits</h1>
+        <p class="habits-subtitle">Track streaks and celebrate consistent wins.</p>
+      </div>
+      <a class="btn-secondary" href="{{ url_for('habits.new_habit') }}">New habit</a>
+    </header>
+
+    {% if habits %}
+      <div class="habit-grid" role="list">
+        {% for habit in habits %}
+          <article class="habit-card" role="listitem">
+            <header class="habit-card-header">
+              <h2>{{ habit.name }}</h2>
+              <span class="streak-badge{% if habit.streak_state %} is-{{ habit.streak_state }}{% endif %}">
+                {{ habit.streak }} day{% if habit.streak != 1 %}s{% endif %}
+              </span>
+            </header>
+
+            <p class="habit-goal">{{ habit.goal }}</p>
+
+            <dl class="habit-meta">
+              <div>
+                <dt>Cadence</dt>
+                <dd>{{ habit.cadence }}</dd>
+              </div>
+              <div>
+                <dt>Last completed</dt>
+                <dd>{{ habit.last_completed_display }}</dd>
+              </div>
+            </dl>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="empty">No habits to show yet. Create your first habit to start tracking streaks.</p>
+    {% endif %}
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load habit records from the database and compute current streak metadata
- render the habits index with responsive cards showing goals and last completion times
- add CSS for the habits grid and streak badges with success and danger color states

## Testing
- pytest tests/test_routes_smoke.py *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68f862ddaef88321af972540316a960a