### PR TITLE
Add ledger pagination and infinite scroll enhancements

### DIFF
--- a/pocketsage/blueprints/ledger/repository.py
+++ b/pocketsage/blueprints/ledger/repository.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Protocol
+from dataclasses import dataclass
+from datetime import datetime, time, timezone
+from typing import Protocol, Sequence
+
+from sqlalchemy import func
+from sqlmodel import Session, select
 
 from ...models.transaction import Transaction
 
@@ -11,8 +16,8 @@ class LedgerRepository(Protocol):
     """Defines persistence operations required by ledger routes."""
 
     def list_transactions(
-        self, *, filters: dict
-    ) -> Iterable[Transaction]:  # pragma: no cover - interface
+        self, *, filters: dict, page: int, per_page: int
+    ) -> tuple[Sequence[Transaction], int]:  # pragma: no cover - interface
         ...
 
     def create_transaction(self, *, payload: dict) -> Transaction:  # pragma: no cover - interface
@@ -28,3 +33,77 @@ class LedgerRepository(Protocol):
 
 
 # TODO(@data-squad): implement SQLModel-backed repository adhering to protocol.
+
+
+@dataclass
+class SQLModelLedgerRepository:
+    """Ledger repository backed by a SQLModel session."""
+
+    session: Session
+
+    def list_transactions(
+        self,
+        *,
+        filters: dict,
+        page: int,
+        per_page: int,
+    ) -> tuple[list[Transaction], int]:
+        """Return paginated transactions and total count matching ``filters``."""
+
+        clauses = []
+
+        search_term = (filters.get("q") or "").strip()
+        if search_term:
+            clauses.append(Transaction.memo.ilike(f"%{search_term}%"))
+
+        start_date = _coerce_date(filters.get("start"), is_start=True)
+        if start_date is not None:
+            clauses.append(Transaction.occurred_at >= start_date)
+
+        end_date = _coerce_date(filters.get("end"), is_start=False)
+        if end_date is not None:
+            clauses.append(Transaction.occurred_at <= end_date)
+
+        sanitized_page = max(page, 1)
+        sanitized_per_page = max(min(per_page, 100), 1)
+        offset = (sanitized_page - 1) * sanitized_per_page
+
+        count_stmt = select(func.count()).select_from(Transaction).where(*clauses)
+        total = self.session.exec(count_stmt).one()
+
+        data_stmt = (
+            select(Transaction)
+            .where(*clauses)
+            .order_by(Transaction.occurred_at.desc(), Transaction.id.desc())
+            .offset(offset)
+            .limit(sanitized_per_page)
+        )
+        rows = self.session.exec(data_stmt).all()
+        return rows, int(total or 0)
+
+
+def _coerce_date(value: str | None, *, is_start: bool) -> datetime | None:
+    """Parse a ``YYYY-MM-DD`` string into a timezone-aware datetime."""
+
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        try:
+            base = datetime.strptime(value, "%Y-%m-%d")
+        except ValueError:
+            return None
+        if is_start:
+            return datetime.combine(base.date(), time.min, tzinfo=timezone.utc)
+        return datetime.combine(base.date(), time.max, tzinfo=timezone.utc)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    if is_start and parsed.time() == time.min:
+        return datetime.combine(parsed.date(), time.min, tzinfo=parsed.tzinfo)
+    if not is_start and parsed.time() == time.min:
+        return datetime.combine(parsed.date(), time.max, tzinfo=parsed.tzinfo)
+    return parsed
+
+
+__all__ = ["LedgerRepository", "SQLModelLedgerRepository"]

--- a/pocketsage/blueprints/ledger/routes.py
+++ b/pocketsage/blueprints/ledger/routes.py
@@ -2,17 +2,81 @@
 
 from __future__ import annotations
 
-from flask import flash, redirect, render_template, request, url_for
+from math import ceil
+
+from flask import flash, g, redirect, render_template, request, url_for
 
 from . import bp
+from .repository import SQLModelLedgerRepository
+
+
+DEFAULT_PER_PAGE = 25
+PER_PAGE_CHOICES = (10, 25, 50, 100)
 
 
 @bp.get("/")
 def list_transactions():
-    """Display ledger transactions with filters and rollups."""
+    """Display ledger transactions with filters, pagination, and rollups."""
 
-    # TODO(@ledger-squad): wire repository filtering + pagination + rollup summary.
-    return render_template("ledger/index.html", filters=request.args)
+    session = g.get("sqlmodel_session")
+    if session is None:
+        raise RuntimeError("Database session not initialized for request")
+
+    requested_page = _coerce_int(request.args.get("page"), default=1)
+    requested_per_page = _coerce_int(
+        request.args.get("per_page"), default=DEFAULT_PER_PAGE, minimum=1, maximum=100
+    )
+
+    filters = {
+        key: value
+        for key, value in request.args.items()
+        if key not in {"page", "per_page"} and value
+    }
+
+    repository = SQLModelLedgerRepository(session=session)
+    transactions, total = repository.list_transactions(
+        filters=filters, page=requested_page, per_page=requested_per_page
+    )
+
+    total_pages = max(ceil(total / requested_per_page), 1) if total else 1
+    current_page = min(max(requested_page, 1), total_pages)
+
+    if total and current_page != requested_page:
+        transactions, _ = repository.list_transactions(
+            filters=filters, page=current_page, per_page=requested_per_page
+        )
+
+    start_index = (current_page - 1) * requested_per_page
+    page_start = start_index + 1 if total else 0
+    page_end = min(start_index + len(transactions), total) if total else 0
+
+    pagination = {
+        "page": current_page,
+        "per_page": requested_per_page,
+        "total": total,
+        "pages": total_pages,
+        "has_prev": current_page > 1,
+        "has_next": current_page < total_pages,
+        "start": page_start,
+        "end": page_end,
+        "window": _pagination_window(current_page, total_pages),
+    }
+
+    def page_url(target_page: int) -> str:
+        params = dict(filters)
+        params["page"] = target_page
+        params["per_page"] = requested_per_page
+        return url_for("ledger.list_transactions", **params)
+
+    context = {
+        "filters": filters,
+        "transactions": transactions,
+        "pagination": pagination,
+        "page_url": page_url,
+        "per_page_options": _per_page_options(requested_per_page),
+    }
+
+    return render_template("ledger/index.html", **context)
 
 
 @bp.get("/new")
@@ -47,3 +111,57 @@ def update_transaction(transaction_id: int):
     # TODO(@ledger-squad): apply optimistic locking + repository update.
     flash("Ledger transaction update not yet implemented", "warning")
     return redirect(url_for("ledger.list_transactions"))
+
+
+def _coerce_int(
+    value: str | None,
+    *,
+    default: int,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    """Convert ``value`` to an ``int`` within optional bounds."""
+
+    try:
+        result = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        result = default
+    if minimum is not None:
+        result = max(result, minimum)
+    if maximum is not None:
+        result = min(result, maximum)
+    return result
+
+
+def _pagination_window(current_page: int, total_pages: int, width: int = 2) -> list[int | None]:
+    """Return a condensed pagination range with ellipses."""
+
+    if total_pages <= (width * 2 + 5):
+        return list(range(1, total_pages + 1))
+
+    window_start = max(current_page - width, 1)
+    window_end = min(current_page + width, total_pages)
+
+    window: list[int | None] = [1]
+
+    if window_start > 2:
+        window.append(None)
+
+    window.extend(range(window_start, window_end + 1))
+
+    if window_end < total_pages - 1:
+        window.append(None)
+
+    if total_pages not in window:
+        window.append(total_pages)
+
+    return window
+
+
+def _per_page_options(selected: int) -> tuple[int, ...]:
+    """Return a sorted tuple of available page sizes including ``selected``."""
+
+    options = list(PER_PAGE_CHOICES)
+    if selected not in options:
+        options.append(selected)
+    return tuple(sorted(dict.fromkeys(options)))

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -155,6 +155,18 @@ body {
     gap: 0.75rem;
 }
 
+.sr-only {
+    border: 0 !important;
+    clip: rect(0, 0, 0, 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+    white-space: nowrap !important;
+}
+
 .portfolio-dashboard {
     display: grid;
     gap: 2rem;
@@ -386,6 +398,220 @@ body {
     display: flex;
     gap: 1rem;
     flex-wrap: wrap;
+}
+
+.ledger-layout {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.ledger-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.ledger-subtitle {
+    margin: 0.25rem 0 0;
+    color: rgba(255, 255, 255, 0.6);
+    max-width: 40ch;
+}
+
+.ledger-filters {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    align-items: end;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+}
+
+.filter-field label {
+    display: block;
+    margin-bottom: 0.35rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.filter-field input,
+.filter-field select {
+    width: 100%;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(15, 23, 42, 0.6);
+    color: inherit;
+    padding: 0.6rem 0.75rem;
+    font-size: 0.95rem;
+}
+
+.filter-field input:focus,
+.filter-field select:focus {
+    outline: 2px solid rgba(59, 130, 246, 0.6);
+    outline-offset: 1px;
+}
+
+.filter-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.ledger-summary {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.ledger-table-wrapper {
+    overflow-x: auto;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(15, 23, 42, 0.45);
+}
+
+.ledger-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 600px;
+}
+
+.ledger-table th,
+.ledger-table td {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    vertical-align: top;
+}
+
+.ledger-table thead th {
+    text-align: left;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.ledger-amount-header,
+.ledger-amount {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+.ledger-amount[data-amount='inflow'] {
+    color: #22c55e;
+}
+
+.ledger-amount[data-amount='outflow'] {
+    color: #f97316;
+}
+
+.ledger-memo {
+    font-weight: 600;
+}
+
+.ledger-reference {
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.ledger-pagination {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.pagination-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.pagination-pages {
+    list-style: none;
+    display: flex;
+    gap: 0.5rem;
+    padding: 0;
+    margin: 0;
+}
+
+.pagination-page {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.15);
+    color: rgba(255, 255, 255, 0.9);
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0 0.75rem;
+}
+
+.pagination-page.is-active {
+    background: #3b82f6;
+    color: #0f172a;
+}
+
+.pagination-ellipsis {
+    opacity: 0.6;
+    padding: 0 0.5rem;
+}
+
+.pagination-prev.is-disabled,
+.pagination-next.is-disabled {
+    opacity: 0.45;
+    pointer-events: none;
+}
+
+.pagination-hint,
+.pagination-noscript {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.ledger-sentinel {
+    display: grid;
+    gap: 0.75rem;
+    justify-items: start;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+}
+
+.ledger-sentinel-status {
+    margin: 0;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.ledger-sentinel[data-inactive="true"] {
+    opacity: 0.7;
+}
+
+@media (max-width: 720px) {
+    .ledger-table {
+        min-width: 100%;
+    }
+
+    .ledger-filters {
+        grid-template-columns: 1fr;
+    }
+
+    .pagination-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
 }
 
 /* TODO(@ux-team): extend design tokens, typography scale, and dark/light mode palettes. */

--- a/pocketsage/static/js/main.js
+++ b/pocketsage/static/js/main.js
@@ -5,6 +5,7 @@ const FINAL_JOB_STATUSES = new Set(["succeeded", "failed"]);
 document.addEventListener("DOMContentLoaded", () => {
     initAdminDashboard();
     initPortfolioUpload();
+    initLedger();
 });
 
 function initAdminDashboard() {
@@ -222,6 +223,147 @@ function initPortfolioUpload() {
             }
         }
     });
+}
+
+function initLedger() {
+    const ledgerRoot = document.querySelector("[data-ledger-root]");
+    if (!ledgerRoot) {
+        return;
+    }
+
+    const tableBody = ledgerRoot.querySelector("[data-ledger-rows]");
+    const pagination = ledgerRoot.querySelector("[data-ledger-pagination]");
+    const sentinel = ledgerRoot.querySelector("[data-ledger-sentinel]");
+
+    if (!tableBody || !pagination) {
+        return;
+    }
+
+    if (sentinel) {
+        sentinel.hidden = false;
+    }
+
+    let nextUrl = null;
+    const nextAnchor = pagination.querySelector("[data-pagination-next]");
+    if (nextAnchor && nextAnchor.getAttribute("href")) {
+        nextUrl = nextAnchor.getAttribute("href");
+    }
+
+    if (!sentinel || !nextUrl) {
+        return;
+    }
+
+    const status = sentinel.querySelector("[data-ledger-status]");
+    const loadMoreButton = sentinel.querySelector("[data-ledger-load-more]");
+
+    const updateStatus = (message, state = "idle") => {
+        if (!status) {
+            return;
+        }
+        status.textContent = message;
+        status.dataset.state = state;
+    };
+
+    const refreshPagination = (doc) => {
+        const newPagination = doc.querySelector("[data-ledger-pagination]");
+        if (newPagination) {
+            pagination.innerHTML = newPagination.innerHTML;
+        }
+        const updatedNext = pagination.querySelector("[data-pagination-next]");
+        if (updatedNext && updatedNext.getAttribute("href")) {
+            nextUrl = updatedNext.getAttribute("href");
+        } else {
+            nextUrl = null;
+        }
+    };
+
+    let observer = null;
+    let loading = false;
+
+    const teardown = () => {
+        if (observer) {
+            observer.disconnect();
+            observer = null;
+        }
+        if (sentinel) {
+            sentinel.dataset.inactive = "true";
+        }
+    };
+
+    const fetchNextPage = async () => {
+        if (loading || !nextUrl) {
+            return;
+        }
+        loading = true;
+        ledgerRoot.dataset.loading = "true";
+        updateStatus("Loading more transactions…", "loading");
+        if (loadMoreButton) {
+            loadMoreButton.disabled = true;
+        }
+
+        try {
+            const response = await fetch(nextUrl, { headers: { Accept: "text/html" } });
+            if (!response.ok) {
+                throw new Error(`Request failed with status ${response.status}`);
+            }
+            const html = await response.text();
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, "text/html");
+            const newRows = doc.querySelectorAll("[data-ledger-rows] tr");
+            if (newRows.length === 0) {
+                nextUrl = null;
+                updateStatus("No additional transactions found.", "done");
+                teardown();
+                return;
+            }
+            newRows.forEach((row) => tableBody.appendChild(row));
+
+            const newSummary = doc.querySelector("[data-ledger-summary]");
+            const currentSummary = ledgerRoot.querySelector("[data-ledger-summary]");
+            if (newSummary && currentSummary) {
+                currentSummary.innerHTML = newSummary.innerHTML;
+            }
+
+            refreshPagination(doc);
+
+            if (nextUrl) {
+                updateStatus("Scroll to load more transactions.");
+            } else {
+                updateStatus("You’re all caught up.", "done");
+                teardown();
+            }
+        } catch (error) {
+            console.warn("Ledger infinite scroll failed", error);
+            updateStatus("Automatic loading paused. Use pagination links above.", "error");
+            teardown();
+        } finally {
+            ledgerRoot.dataset.loading = "false";
+            if (loadMoreButton) {
+                loadMoreButton.disabled = false;
+            }
+            loading = false;
+        }
+    };
+
+    if (loadMoreButton) {
+        loadMoreButton.addEventListener("click", fetchNextPage);
+    }
+
+    observer = new IntersectionObserver(
+        (entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    fetchNextPage();
+                }
+            });
+        },
+        { rootMargin: "0px 0px 200px 0px" }
+    );
+
+    observer.observe(sentinel);
+
+    ledgerRoot.dataset.enhanced = "true";
+    updateStatus("Scroll to load more transactions.");
 }
 
 function safeParseJSON(value) {

--- a/pocketsage/templates/ledger/index.html
+++ b/pocketsage/templates/ledger/index.html
@@ -1,6 +1,159 @@
 {% extends 'base.html' %}
 {% block title %}Ledger · PocketSage{% endblock %}
 {% block content %}
-  <h1>Ledger</h1>
-  <p class="todo">TODO(@ledger-squad): render transaction table, filters, and rollups.</p>
+  <section class="ledger-layout" data-ledger-root>
+    <header class="ledger-header">
+      <div>
+        <h1>Ledger</h1>
+        <p class="ledger-subtitle">Review recent activity, refine results, and export insights.</p>
+      </div>
+      <a href="{{ url_for('admin.index') }}" class="btn-secondary">Exports &amp; reports</a>
+    </header>
+
+    <form method="get" class="ledger-filters" data-ledger-filters aria-label="Ledger filters">
+      <div class="filter-field">
+        <label for="filter-q">Search</label>
+        <input
+          type="search"
+          id="filter-q"
+          name="q"
+          placeholder="Find by memo"
+          value="{{ filters.get('q', '') }}"
+        >
+      </div>
+      <div class="filter-field">
+        <label for="filter-start">From</label>
+        <input
+          type="date"
+          id="filter-start"
+          name="start"
+          value="{{ filters.get('start', '') }}"
+        >
+      </div>
+      <div class="filter-field">
+        <label for="filter-end">To</label>
+        <input
+          type="date"
+          id="filter-end"
+          name="end"
+          value="{{ filters.get('end', '') }}"
+        >
+      </div>
+      <div class="filter-field">
+        <label for="filter-per-page">Rows per page</label>
+        <select id="filter-per-page" name="per_page">
+          {% for option in per_page_options %}
+            <option value="{{ option }}"{% if option == pagination.per_page %} selected{% endif %}>{{ option }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="filter-actions">
+        <button type="submit" class="btn-primary">Apply filters</button>
+        {% if filters %}
+          <a href="{{ url_for('ledger.list_transactions') }}" class="btn-link">Reset</a>
+        {% endif %}
+      </div>
+    </form>
+
+    <div class="ledger-summary" data-ledger-summary>
+      {% if pagination.total %}
+        <p>Showing <strong>{{ pagination.start }}</strong>–<strong>{{ pagination.end }}</strong> of <strong>{{ pagination.total }}</strong> transactions.</p>
+      {% elif filters %}
+        <p>No transactions match your current filters.</p>
+      {% else %}
+        <p>No transactions yet — import data or add your first entry.</p>
+      {% endif %}
+    </div>
+
+    <div class="ledger-table-wrapper">
+      <table class="ledger-table" role="grid">
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Description</th>
+            <th scope="col" class="ledger-amount-header">Amount</th>
+            <th scope="col">Currency</th>
+          </tr>
+        </thead>
+        <tbody data-ledger-rows>
+          {% if transactions %}
+            {% for tx in transactions %}
+              <tr>
+                <td data-header="Date">
+                  {% if tx.occurred_at %}
+                    {{ tx.occurred_at.strftime('%b %d, %Y %H:%M') }}
+                  {% else %}
+                    —
+                  {% endif %}
+                </td>
+                <td data-header="Description">
+                  <div class="ledger-memo">{{ tx.memo or '—' }}</div>
+                  {% if tx.external_id %}
+                    <div class="ledger-reference">Ref {{ tx.external_id }}</div>
+                  {% endif %}
+                </td>
+                {% set amount = "{:+,.2f}".format(tx.amount) %}
+                <td data-header="Amount" class="ledger-amount" data-amount="{{ 'inflow' if tx.amount >= 0 else 'outflow' }}">
+                  <span class="sr-only">{{ 'Inflow' if tx.amount >= 0 else 'Outflow' }} </span>{{ amount }}
+                </td>
+                <td data-header="Currency">{{ tx.currency or 'USD' }}</td>
+              </tr>
+            {% endfor %}
+          {% else %}
+            <tr>
+              <td colspan="4" class="empty">No transactions to display.</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+
+    <nav class="ledger-pagination" aria-label="Ledger pagination" data-ledger-pagination>
+      <div class="pagination-controls">
+        {% set prev_url = page_url(pagination.page - 1) %}
+        <a
+          class="btn-link pagination-prev{% if not pagination.has_prev %} is-disabled{% endif %}"
+          {% if pagination.has_prev %}href="{{ prev_url }}"{% else %}aria-disabled="true" tabindex="-1"{% endif %}
+        >
+          Previous
+        </a>
+        <ul class="pagination-pages">
+          {% for number in pagination.window %}
+            {% if number %}
+              <li>
+                {% if number == pagination.page %}
+                  <span class="pagination-page is-active" aria-current="page">{{ number }}</span>
+                {% else %}
+                  <a href="{{ page_url(number) }}" class="pagination-page">{{ number }}</a>
+                {% endif %}
+              </li>
+            {% else %}
+              <li class="pagination-ellipsis" aria-hidden="true">…</li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+        {% set next_url = page_url(pagination.page + 1) %}
+        <a
+          class="btn-link pagination-next{% if not pagination.has_next %} is-disabled{% endif %}"
+          data-pagination-next
+          {% if pagination.has_next %}href="{{ next_url }}"{% else %}aria-disabled="true" tabindex="-1"{% endif %}
+        >
+          Next
+        </a>
+      </div>
+      <p class="pagination-hint">Use the pagination controls or enable automatic loading below.</p>
+      <noscript>
+        <p class="pagination-noscript">JavaScript is disabled; use the links above to navigate pages.</p>
+      </noscript>
+    </nav>
+
+    {% if pagination.has_next %}
+      <div class="ledger-sentinel" data-ledger-sentinel hidden>
+        <p class="ledger-sentinel-status" data-ledger-status aria-live="polite">
+          Scroll to load more transactions.
+        </p>
+        <button type="button" class="btn-secondary" data-ledger-load-more>Load more</button>
+      </div>
+    {% endif %}
+  </section>
 {% endblock %}

--- a/tests/test_ledger_repository.py
+++ b/tests/test_ledger_repository.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from pocketsage.blueprints.ledger.repository import SQLModelLedgerRepository
+from pocketsage.models.transaction import Transaction
+
+
+def build_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    return Session(engine)
+
+
+def seed_transactions(session: Session, count: int = 5) -> None:
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    for idx in range(count):
+        session.add(
+            Transaction(
+                occurred_at=base + timedelta(days=idx),
+                amount=float(idx),
+                memo=f"Item {idx}",
+                currency="USD",
+            )
+        )
+    session.commit()
+
+
+def test_list_transactions_returns_total_and_page() -> None:
+    session = build_session()
+    try:
+        seed_transactions(session, count=5)
+
+        repository = SQLModelLedgerRepository(session=session)
+
+        rows, total = repository.list_transactions(filters={}, page=1, per_page=2)
+
+        assert total == 5
+        assert len(rows) == 2
+        assert rows[0].memo == "Item 4"
+        assert rows[1].memo == "Item 3"
+    finally:
+        session.close()
+
+
+def test_list_transactions_applies_filters() -> None:
+    session = build_session()
+    try:
+        seed_transactions(session, count=4)
+
+        repository = SQLModelLedgerRepository(session=session)
+
+        rows, total = repository.list_transactions(filters={"q": "Item 2"}, page=1, per_page=10)
+        assert total == 1
+        assert rows[0].memo == "Item 2"
+
+        rows, total = repository.list_transactions(filters={"start": "2024-01-03"}, page=1, per_page=10)
+        assert total == 2
+        assert rows[0].memo == "Item 3"
+        assert rows[1].memo == "Item 2"
+
+        rows, total = repository.list_transactions(filters={"end": "2024-01-02"}, page=1, per_page=10)
+        assert total == 3
+        assert rows[-1].memo == "Item 0"
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- extend the ledger repository to provide paginated results with total counts and filtering helpers
- render the ledger page with filter form, pagination controls, and infinite scroll sentinel that preserves active query parameters
- add supporting styles, JavaScript enhancements, and repository unit tests covering pagination and filter behaviour

## Testing
- pytest *(fails: environment is missing Flask and SQLModel dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f862e0f6f48321b742e5bf5ee22100