### PR TITLE
Add ledger filters UI and repository support

### DIFF
--- a/pocketsage/blueprints/ledger/repository.py
+++ b/pocketsage/blueprints/ledger/repository.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime, time
 from typing import Iterable, Protocol
 
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from ...models.category import Category
 from ...models.transaction import Transaction
 
 
@@ -13,6 +18,9 @@ class LedgerRepository(Protocol):
     def list_transactions(
         self, *, filters: dict
     ) -> Iterable[Transaction]:  # pragma: no cover - interface
+        ...
+
+    def list_categories(self) -> Iterable[Category]:  # pragma: no cover - interface
         ...
 
     def create_transaction(self, *, payload: dict) -> Transaction:  # pragma: no cover - interface
@@ -27,4 +35,48 @@ class LedgerRepository(Protocol):
         ...
 
 
-# TODO(@data-squad): implement SQLModel-backed repository adhering to protocol.
+class SqlModelLedgerRepository:
+    """SQLModel-backed ledger repository with filtering support."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def list_transactions(self, *, filters: dict) -> list[Transaction]:
+        stmt = select(Transaction)
+
+        start_date: date | None = filters.get("start_date")
+        if start_date is not None:
+            start_dt = datetime.combine(start_date, time.min)
+            stmt = stmt.where(Transaction.occurred_at >= start_dt)
+
+        end_date: date | None = filters.get("end_date")
+        if end_date is not None:
+            end_dt = datetime.combine(end_date, time.max).replace(microsecond=999999)
+            stmt = stmt.where(Transaction.occurred_at <= end_dt)
+
+        category_id: int | None = filters.get("category_id")
+        if category_id is not None:
+            stmt = stmt.where(Transaction.category_id == category_id)
+
+        search: str | None = filters.get("search")
+        if search:
+            pattern = f"%{search.lower()}%"
+            stmt = stmt.where(func.lower(Transaction.memo).like(pattern))
+
+        stmt = stmt.order_by(Transaction.occurred_at.desc())
+        return list(self._session.exec(stmt))
+
+    def list_categories(self) -> list[Category]:
+        stmt = select(Category).order_by(Category.name)
+        return list(self._session.exec(stmt))
+
+    def create_transaction(self, *, payload: dict) -> Transaction:  # pragma: no cover - stub
+        raise NotImplementedError
+
+    def update_transaction(
+        self,
+        transaction_id: int,
+        *,
+        payload: dict,
+    ) -> Transaction:  # pragma: no cover - stub
+        raise NotImplementedError

--- a/pocketsage/blueprints/ledger/routes.py
+++ b/pocketsage/blueprints/ledger/routes.py
@@ -2,17 +2,89 @@
 
 from __future__ import annotations
 
-from flask import flash, redirect, render_template, request, url_for
+from datetime import date
+from typing import Any, Tuple
+
+from flask import flash, g, redirect, render_template, request, url_for
 
 from . import bp
+from .repository import SqlModelLedgerRepository
+
+
+def _parse_date(value: str | None) -> date | None:
+    """Attempt to parse ISO-8601 date strings."""
+
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _extract_filters(args) -> Tuple[dict[str, Any], dict[str, str]]:
+    """Convert request arguments into repository filters and form state."""
+
+    form_state: dict[str, str] = {
+        "start_date": args.get("start_date", ""),
+        "end_date": args.get("end_date", ""),
+        "category": args.get("category", ""),
+        "search": args.get("search", ""),
+    }
+
+    filters: dict[str, Any] = {}
+
+    start_date = _parse_date(form_state["start_date"] or None)
+    if start_date is not None:
+        filters["start_date"] = start_date
+        form_state["start_date"] = start_date.isoformat()
+    else:
+        form_state["start_date"] = ""
+
+    end_date = _parse_date(form_state["end_date"] or None)
+    if end_date is not None:
+        filters["end_date"] = end_date
+        form_state["end_date"] = end_date.isoformat()
+    else:
+        form_state["end_date"] = ""
+
+    category_raw = (form_state["category"] or "").strip()
+    if category_raw:
+        try:
+            filters["category_id"] = int(category_raw)
+            form_state["category"] = str(filters["category_id"])
+        except ValueError:
+            form_state["category"] = ""
+    else:
+        form_state["category"] = ""
+
+    search_raw = (form_state["search"] or "").strip()
+    if search_raw:
+        filters["search"] = search_raw
+        form_state["search"] = search_raw
+    else:
+        form_state["search"] = ""
+
+    return filters, form_state
 
 
 @bp.get("/")
 def list_transactions():
     """Display ledger transactions with filters and rollups."""
 
-    # TODO(@ledger-squad): wire repository filtering + pagination + rollup summary.
-    return render_template("ledger/index.html", filters=request.args)
+    filters, form_state = _extract_filters(request.args)
+    repo = SqlModelLedgerRepository(g.sqlmodel_session)
+    transactions = repo.list_transactions(filters=filters)
+    categories = repo.list_categories()
+
+    # TODO(@ledger-squad): wire pagination + rollup summary calculations.
+    return render_template(
+        "ledger/index.html",
+        filters=filters,
+        filter_state=form_state,
+        transactions=transactions,
+        categories=categories,
+    )
 
 
 @bp.get("/new")

--- a/pocketsage/templates/ledger/index.html
+++ b/pocketsage/templates/ledger/index.html
@@ -2,5 +2,60 @@
 {% block title %}Ledger · PocketSage{% endblock %}
 {% block content %}
   <h1>Ledger</h1>
-  <p class="todo">TODO(@ledger-squad): render transaction table, filters, and rollups.</p>
+  {% set selected_category = filter_state.category %}
+  <form method="get" class="filter-toolbar">
+    <fieldset>
+      <legend class="sr-only">Filter transactions</legend>
+      <div class="filter-row">
+        <label>
+          From
+          <input type="date" name="start_date" value="{{ filter_state.start_date }}">
+        </label>
+        <label>
+          To
+          <input type="date" name="end_date" value="{{ filter_state.end_date }}">
+        </label>
+        <label>
+          Category
+          <select name="category">
+            <option value="">All categories</option>
+            {% for category in categories %}
+              <option value="{{ category.id }}" {% if selected_category and selected_category|int == category.id %}selected{% endif %}>{{ category.name }}</option>
+            {% endfor %}
+          </select>
+        </label>
+        <label>
+          Search
+          <input type="search" name="search" value="{{ filter_state.search }}" placeholder="Memo contains…">
+        </label>
+        <button type="submit">Apply</button>
+        <a class="button button-secondary" href="{{ url_for('ledger.list_transactions') }}">Reset</a>
+      </div>
+    </fieldset>
+  </form>
+
+  {% if transactions %}
+    <table class="ledger-table">
+      <thead>
+        <tr>
+          <th scope="col">Date</th>
+          <th scope="col">Category</th>
+          <th scope="col">Memo</th>
+          <th scope="col" class="numeric">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for transaction in transactions %}
+          <tr>
+            <td>{{ transaction.occurred_at.strftime('%Y-%m-%d') }}</td>
+            <td>{{ transaction.category.name if transaction.category else 'Uncategorized' }}</td>
+            <td>{{ transaction.memo }}</td>
+            <td class="numeric">{{ '%.2f'|format(transaction.amount) }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="empty-state">No transactions match the current filters.</p>
+  {% endif %}
 {% endblock %}

--- a/tests/test_ledger_filters.py
+++ b/tests/test_ledger_filters.py
@@ -1,0 +1,131 @@
+"""Tests covering ledger filter interactions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from flask import template_rendered
+
+from pocketsage import create_app
+from pocketsage.extensions import session_scope
+from pocketsage.models import Category, Transaction
+
+
+@pytest.fixture()
+def ledger_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    db_path = tmp_path / "ledger.db"
+    monkeypatch.setenv("POCKETSAGE_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("POCKETSAGE_DATABASE_URL", f"sqlite:///{db_path}")
+    app = create_app("development")
+    app.testing = True
+    return app
+
+
+@pytest.fixture()
+def ledger_client(ledger_app):
+    with ledger_app.test_client() as client:
+        yield client
+
+
+@pytest.fixture()
+def captured_templates(ledger_app) -> Iterator[list]:
+    recorded: list = []
+
+    def _record(sender, template, context, **extra):  # pragma: no cover - flask internals
+        recorded.append((template, context))
+
+    template_rendered.connect(_record, ledger_app)
+    try:
+        yield recorded
+    finally:
+        template_rendered.disconnect(_record, ledger_app)
+
+
+@pytest.fixture()
+def sample_ledger_data(ledger_app):
+    with ledger_app.app_context():
+        with session_scope() as session:
+            income = Category(name="Salary", slug="salary", category_type="income")
+            expense = Category(name="Coffee", slug="coffee", category_type="expense")
+            session.add(income)
+            session.add(expense)
+            session.flush()
+
+            transactions = [
+                Transaction(
+                    occurred_at=datetime(2024, 1, 5, 8, 30),
+                    amount=1500.00,
+                    memo="January salary",
+                    category_id=income.id,
+                ),
+                Transaction(
+                    occurred_at=datetime(2024, 1, 6, 9, 15),
+                    amount=-5.75,
+                    memo="Morning Coffee",
+                    category_id=expense.id,
+                ),
+                Transaction(
+                    occurred_at=datetime(2024, 2, 1, 12, 0),
+                    amount=-42.10,
+                    memo="Groceries",
+                    category_id=expense.id,
+                ),
+            ]
+            session.add_all(transactions)
+            session.flush()
+
+            return {
+                "expense_id": expense.id,
+                "transaction_count": len(transactions),
+            }
+
+
+def test_ledger_filters_apply_query_parameters(
+    ledger_client, captured_templates, sample_ledger_data
+):
+    expense_id = sample_ledger_data["expense_id"]
+    response = ledger_client.get(
+        f"/ledger/?start_date=2024-01-06&end_date=2024-01-06&category={expense_id}&search=coffee"
+    )
+
+    assert response.status_code == 200
+    assert captured_templates
+    _, context = captured_templates[-1]
+
+    state = context["filter_state"]
+    assert state["start_date"] == "2024-01-06"
+    assert state["end_date"] == "2024-01-06"
+    assert state["category"] == str(expense_id)
+    assert state["search"] == "coffee"
+
+    transactions = context["transactions"]
+    assert len(transactions) == 1
+    assert transactions[0].memo == "Morning Coffee"
+
+    body = response.get_data(as_text=True)
+    assert "value=\"2024-01-06\"" in body
+    assert f'<option value="{expense_id}" selected' in body
+    assert 'value="coffee"' in body
+
+
+def test_invalid_filters_reset_state(ledger_client, captured_templates, sample_ledger_data):
+    response = ledger_client.get("/ledger/?start_date=oops&category=not-a-number&search= ")
+
+    assert response.status_code == 200
+    _, context = captured_templates[-1]
+
+    state = context["filter_state"]
+    assert state["start_date"] == ""
+    assert state["end_date"] == ""
+    assert state["category"] == ""
+    assert state["search"] == ""
+
+    filters = context["filters"]
+    assert filters == {}
+
+    transactions = context["transactions"]
+    assert len(transactions) == sample_ledger_data["transaction_count"]
+


### PR DESCRIPTION
## Summary
- parse ledger query parameters into typed filters and expose them to the template
- implement an SQLModel-backed ledger repository with filtering and category listings
- build a filter toolbar on the ledger page and add tests covering query/UI interactions

## Testing
- pytest tests/test_ledger_filters.py
- pytest tests/test_routes_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68f862e224488321bcea03504aaf1a69