### PR TITLE
Add accessible flash notifications with dismissal

### DIFF
--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -40,6 +40,27 @@ body {
     border-radius: 0.5rem;
     padding: 0.75rem 1rem;
     margin-bottom: 0.5rem;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 0.75rem;
+    align-items: start;
+}
+
+.flash-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 0.1rem;
+}
+
+.flash-icon svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    display: block;
+}
+
+.flash-message {
+    line-height: 1.4;
 }
 
 .flash-success {
@@ -50,6 +71,49 @@ body {
 .flash-warning {
     background: rgba(251, 191, 36, 0.15);
     color: #fbbf24;
+}
+
+.flash-danger {
+    background: rgba(248, 113, 113, 0.15);
+    color: #f87171;
+}
+
+.flash-error {
+    background: rgba(248, 113, 113, 0.15);
+    color: #f87171;
+}
+
+.flash-dismiss {
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 0.375rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.flash-dismiss svg {
+    width: 1rem;
+    height: 1rem;
+    display: block;
+    pointer-events: none;
+}
+
+.flash-dismiss:hover,
+.flash-dismiss:focus-visible {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.flash-dismiss:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+
+.flash-dismiss:active {
+    transform: scale(0.95);
 }
 
 .flash-info {

--- a/pocketsage/static/js/main.js
+++ b/pocketsage/static/js/main.js
@@ -1,11 +1,43 @@
 // PocketSage frontend bootstrapping
 
 const FINAL_JOB_STATUSES = new Set(["succeeded", "failed"]);
+const ALERT_FLASH_CATEGORIES = new Set(["danger", "warning", "error"]);
+
+const FLASH_ICONS = Object.freeze({
+    success: `<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.707a1 1 0 00-1.414-1.414L9 10.172 7.707 8.879a1 1 0 10-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path></svg>`,
+    danger: `<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-9-3a1 1 0 112 0v4a1 1 0 11-2 0V7zm1 8a1.25 1.25 0 100-2.5A1.25 1.25 0 0010 15z" clip-rule="evenodd"></path></svg>`,
+    error: `<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-9-3a1 1 0 112 0v4a1 1 0 11-2 0V7zm1 8a1.25 1.25 0 100-2.5A1.25 1.25 0 0010 15z" clip-rule="evenodd"></path></svg>`,
+    warning: `<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l6.518 11.59c.75 1.333-.214 2.99-1.742 2.99H3.48c-1.528 0-2.492-1.657-1.742-2.99l6.52-11.59zM11 14a1 1 0 10-2 0 1 1 0 002 0zm-1-2a1 1 0 01-1-1V8a1 1 0 112 0v3a1 1 0 01-1 1z"></path></svg>`,
+    info: `<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM9 9a1 1 0 112 0v5a1 1 0 11-2 0V9zm1-4a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd"></path></svg>`,
+});
+
+const FLASH_DISMISS_ICON =
+    '<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>';
 
 document.addEventListener("DOMContentLoaded", () => {
+    initFlashDismissal();
     initAdminDashboard();
     initPortfolioUpload();
 });
+
+function initFlashDismissal() {
+    const container = document.querySelector(".flash-messages");
+    if (!container) {
+        return;
+    }
+
+    container.addEventListener("click", (event) => {
+        const dismissButton = event.target.closest("[data-flash-dismiss]");
+        if (!dismissButton || !container.contains(dismissButton)) {
+            return;
+        }
+        event.preventDefault();
+        const flash = dismissButton.closest(".flash");
+        if (flash) {
+            flash.remove();
+        }
+    });
+}
 
 function initAdminDashboard() {
     const adminRoot = document.querySelector("[data-admin-dashboard]");
@@ -269,14 +301,43 @@ function formatDate(value) {
     return date.toLocaleString();
 }
 
+function getFlashIconMarkup(category) {
+    const normalized = typeof category === "string" ? category.toLowerCase() : "";
+    return FLASH_ICONS[normalized] || FLASH_ICONS.info;
+}
+
 function showFlash(message, category) {
     const container = document.querySelector(".flash-messages");
     if (!container) {
         return;
     }
+    const normalizedCategory = (typeof category === "string" && category.trim())
+        ? category.trim().toLowerCase()
+        : "info";
     const element = document.createElement("div");
-    element.className = `flash flash-${category}`;
-    element.textContent = message;
+    element.className = `flash flash-${normalizedCategory}`;
+    element.setAttribute("role", ALERT_FLASH_CATEGORIES.has(normalizedCategory) ? "alert" : "status");
+
+    const icon = document.createElement("span");
+    icon.className = "flash-icon";
+    icon.setAttribute("aria-hidden", "true");
+    icon.innerHTML = getFlashIconMarkup(normalizedCategory);
+
+    const content = document.createElement("div");
+    content.className = "flash-message";
+    content.textContent = message;
+
+    const dismissButton = document.createElement("button");
+    dismissButton.type = "button";
+    dismissButton.className = "flash-dismiss";
+    dismissButton.setAttribute("aria-label", "Dismiss notification");
+    dismissButton.setAttribute("data-flash-dismiss", "");
+    dismissButton.innerHTML = FLASH_DISMISS_ICON;
+    dismissButton.addEventListener("click", () => {
+        element.remove();
+    });
+
+    element.append(icon, content, dismissButton);
     container.appendChild(element);
     setTimeout(() => {
         element.remove();

--- a/pocketsage/templates/_flash.html
+++ b/pocketsage/templates/_flash.html
@@ -1,8 +1,37 @@
+{% macro flash_icon(category) %}
+  {% if category == "success" %}
+    <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.707a1 1 0 00-1.414-1.414L9 10.172 7.707 8.879a1 1 0 10-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+    </svg>
+  {% elif category in ["danger", "error"] %}
+    <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-9-3a1 1 0 112 0v4a1 1 0 11-2 0V7zm1 8a1.25 1.25 0 100-2.5A1.25 1.25 0 0010 15z" clip-rule="evenodd"></path>
+    </svg>
+  {% elif category == "warning" %}
+    <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l6.518 11.59c.75 1.333-.214 2.99-1.742 2.99H3.48c-1.528 0-2.492-1.657-1.742-2.99l6.52-11.59zM11 14a1 1 0 10-2 0 1 1 0 002 0zm-1-2a1 1 0 01-1-1V8a1 1 0 112 0v3a1 1 0 01-1 1z"></path>
+    </svg>
+  {% else %}
+    <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM9 9a1 1 0 112 0v5a1 1 0 11-2 0V9zm1-4a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd"></path>
+    </svg>
+  {% endif %}
+{% endmacro %}
+
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
     <section class="flash-messages">
       {% for category, message in messages %}
-        <div class="flash flash-{{ category }}">{{ message }}</div>
+        {% set role = "alert" if category in ["danger", "warning", "error"] else "status" %}
+        <div class="flash flash-{{ category }}" role="{{ role }}">
+          <span class="flash-icon" aria-hidden="true">{{ flash_icon(category)|safe }}</span>
+          <div class="flash-message">{{ message }}</div>
+          <button type="button" class="flash-dismiss" data-flash-dismiss aria-label="Dismiss notification">
+            <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+            </svg>
+          </button>
+        </div>
       {% endfor %}
     </section>
   {% endif %}


### PR DESCRIPTION
## Summary
- add semantic roles, icons, and dismiss controls to rendered flash messages
- style flash notifications with icon and close button treatments, including focus-visible affordances
- enhance the showFlash helper to inject full flash markup and wire up the dismiss action

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f862e30310832191c6402a81223561