### PR TITLE
Implement repository-backed ledger list view

### DIFF
--- a/pocketsage/blueprints/ledger/repository.py
+++ b/pocketsage/blueprints/ledger/repository.py
@@ -2,17 +2,98 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Protocol
+from dataclasses import dataclass
+from datetime import datetime
+from math import ceil
+from typing import Iterable, Protocol, Sequence
+
+from sqlalchemy import case, func
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
 
 from ...models.transaction import Transaction
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerSummary:
+    """Aggregate cashflow metrics for a slice of ledger data."""
+
+    inflow: float = 0.0
+    outflow: float = 0.0
+    net: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerPagination:
+    """Pagination metadata for ledger listings."""
+
+    page: int
+    per_page: int
+    total: int
+
+    @property
+    def pages(self) -> int:
+        """Return the total number of pages for the current result set."""
+
+        if self.total == 0:
+            return 0
+        return ceil(self.total / self.per_page)
+
+    @property
+    def has_prev(self) -> bool:
+        return self.page > 1 and self.total > 0
+
+    @property
+    def has_next(self) -> bool:
+        pages = self.pages
+        return pages > 0 and self.page < pages
+
+    @property
+    def first_item(self) -> int:
+        if self.total == 0:
+            return 0
+        return (self.page - 1) * self.per_page + 1
+
+    @property
+    def last_item(self) -> int:
+        if self.total == 0:
+            return 0
+        return min(self.page * self.per_page, self.total)
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerTransactionRow:
+    """A lightweight projection of a transaction for presentation."""
+
+    id: int
+    occurred_at: datetime
+    memo: str
+    amount: float
+    currency: str
+    account_name: str | None
+    category_name: str | None
+    external_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerListResult:
+    """Container bundling transaction rows with summary + pagination."""
+
+    transactions: Sequence[LedgerTransactionRow]
+    summary: LedgerSummary
+    pagination: LedgerPagination
 
 
 class LedgerRepository(Protocol):
     """Defines persistence operations required by ledger routes."""
 
     def list_transactions(
-        self, *, filters: dict
-    ) -> Iterable[Transaction]:  # pragma: no cover - interface
+        self,
+        *,
+        filters: dict,
+        page: int,
+        per_page: int,
+    ) -> LedgerListResult:  # pragma: no cover - interface
         ...
 
     def create_transaction(self, *, payload: dict) -> Transaction:  # pragma: no cover - interface
@@ -27,4 +108,120 @@ class LedgerRepository(Protocol):
         ...
 
 
-# TODO(@data-squad): implement SQLModel-backed repository adhering to protocol.
+class SqlModelLedgerRepository:
+    """SQLModel-backed ledger repository used by the Flask blueprint."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def list_transactions(
+        self,
+        *,
+        filters: dict,
+        page: int,
+        per_page: int,
+    ) -> LedgerListResult:
+        page = max(page, 1)
+        per_page = max(per_page, 1)
+
+        where_clauses = self._build_filters(filters)
+
+        count_stmt = select(func.count()).select_from(Transaction)
+        if where_clauses:
+            count_stmt = count_stmt.where(*where_clauses)
+        total = int(self.session.exec(count_stmt).one() or 0)
+
+        stmt = (
+            select(Transaction)
+            .options(
+                selectinload(Transaction.account),
+                selectinload(Transaction.category),
+            )
+            .order_by(Transaction.occurred_at.desc(), Transaction.id.desc())
+        )
+        if where_clauses:
+            stmt = stmt.where(*where_clauses)
+
+        if total and (page - 1) * per_page >= total:
+            # Clamp page to final page if the requested page exceeds bounds.
+            page = ceil(total / per_page)
+
+        offset = (page - 1) * per_page
+        rows = self.session.exec(stmt.offset(offset).limit(per_page)).all()
+
+        transactions = [self._project_transaction(txn) for txn in rows]
+
+        summary = self._compute_summary(where_clauses)
+        pagination = LedgerPagination(page=page, per_page=per_page, total=total)
+
+        return LedgerListResult(
+            transactions=transactions,
+            summary=summary,
+            pagination=pagination,
+        )
+
+    # internal helpers -------------------------------------------------
+
+    def _build_filters(self, filters: dict) -> list:
+        clauses: list = []
+        search = (filters.get("q") or filters.get("search") or "").strip()
+        if search:
+            like = f"%{search.lower()}%"
+            clauses.append(func.lower(Transaction.memo).like(like))
+
+        for key, column in (
+            ("category_id", Transaction.category_id),
+            ("account_id", Transaction.account_id),
+        ):
+            value = filters.get(key)
+            if value in (None, ""):
+                continue
+            try:
+                numeric = int(value)
+            except (TypeError, ValueError):
+                continue
+            clauses.append(column == numeric)
+
+        return clauses
+
+    def _project_transaction(self, txn: Transaction) -> LedgerTransactionRow:
+        account_name: str | None = None
+        if txn.account is not None:
+            account_name = txn.account.name
+        elif txn.account_id is not None:
+            account_name = f"Account #{txn.account_id}"
+
+        category_name: str | None = None
+        if txn.category is not None:
+            category_name = txn.category.name
+
+        return LedgerTransactionRow(
+            id=txn.id or 0,
+            occurred_at=txn.occurred_at,
+            memo=txn.memo or "",
+            amount=float(txn.amount or 0.0),
+            currency=(txn.currency or "USD").upper(),
+            account_name=account_name,
+            category_name=category_name,
+            external_id=txn.external_id,
+        )
+
+    def _compute_summary(self, where_clauses: Iterable) -> LedgerSummary:
+        inflow_case = case((Transaction.amount > 0, Transaction.amount), else_=0.0)
+        outflow_case = case((Transaction.amount < 0, Transaction.amount), else_=0.0)
+
+        summary_stmt = select(
+            func.coalesce(func.sum(inflow_case), 0.0),
+            func.coalesce(func.sum(outflow_case), 0.0),
+        ).select_from(Transaction)
+
+        if where_clauses:
+            summary_stmt = summary_stmt.where(*where_clauses)
+
+        inflow_raw, outflow_raw = self.session.exec(summary_stmt).one()
+        inflow = float(inflow_raw or 0.0)
+        outflow = abs(float(outflow_raw or 0.0))
+        net = inflow - outflow
+
+        return LedgerSummary(inflow=inflow, outflow=outflow, net=net)
+

--- a/pocketsage/blueprints/ledger/routes.py
+++ b/pocketsage/blueprints/ledger/routes.py
@@ -2,17 +2,75 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 from flask import flash, redirect, render_template, request, url_for
 
+from ...extensions import session_scope
 from . import bp
+from .repository import SqlModelLedgerRepository
+
+DEFAULT_PAGE_SIZE = 25
+MAX_PAGE_SIZE = 100
+
+
+def _clean_filters(args: Mapping[str, str]) -> dict[str, str]:
+    """Normalize query-string filters for repository consumption."""
+
+    skip_keys = {"page", "per_page"}
+    return {k: v for k, v in args.items() if k not in skip_keys and v}
+
+
+def _parse_positive_int(value: str | None, *, default: int, upper: int | None = None) -> int:
+    """Parse integer query params while enforcing sane bounds."""
+
+    try:
+        parsed = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+    if parsed < 1:
+        parsed = default
+
+    if upper is not None:
+        parsed = min(parsed, upper)
+
+    return parsed
 
 
 @bp.get("/")
 def list_transactions():
     """Display ledger transactions with filters and rollups."""
 
-    # TODO(@ledger-squad): wire repository filtering + pagination + rollup summary.
-    return render_template("ledger/index.html", filters=request.args)
+    filters = _clean_filters(request.args)
+    page = _parse_positive_int(request.args.get("page"), default=1)
+    per_page = _parse_positive_int(
+        request.args.get("per_page"), default=DEFAULT_PAGE_SIZE, upper=MAX_PAGE_SIZE
+    )
+
+    with session_scope() as session:
+        repo = SqlModelLedgerRepository(session)
+        result = repo.list_transactions(filters=filters, page=page, per_page=per_page)
+
+    pagination = result.pagination
+
+    def _page_url(target_page: int) -> str:
+        params: dict[str, Any] = {**filters, "page": target_page, "per_page": pagination.per_page}
+        return url_for("ledger.list_transactions", **params)
+
+    prev_url = _page_url(pagination.page - 1) if pagination.has_prev else None
+    next_url = _page_url(pagination.page + 1) if pagination.has_next else None
+
+    return render_template(
+        "ledger/index.html",
+        filters=filters,
+        transactions=result.transactions,
+        summary=result.summary,
+        pagination=pagination,
+        prev_url=prev_url,
+        next_url=next_url,
+    )
 
 
 @bp.get("/new")

--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -388,4 +388,220 @@ body {
     flex-wrap: wrap;
 }
 
+.ledger-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.ledger-heading h1 {
+    margin: 0;
+}
+
+.ledger-subtitle {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.ledger-summary {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    margin: 0;
+    padding: 0;
+}
+
+.ledger-summary-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    display: grid;
+    gap: 0.35rem;
+}
+
+.ledger-summary-card dt {
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: rgba(255, 255, 255, 0.65);
+    margin: 0;
+}
+
+.ledger-summary-card dd {
+    margin: 0;
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-weight: 700;
+}
+
+.ledger-summary-card--inflow dd,
+.ledger-amount--inflow {
+    color: #22c55e;
+}
+
+.ledger-summary-card--outflow dd,
+.ledger-amount--outflow {
+    color: #ef4444;
+}
+
+.ledger-summary-card--net dd {
+    color: #38bdf8;
+}
+
+.ledger-table {
+    display: grid;
+    gap: 1rem;
+}
+
+.ledger-table-wrapper {
+    overflow-x: auto;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.ledger-transactions {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 640px;
+}
+
+.ledger-transactions th,
+.ledger-transactions td {
+    padding: 0.85rem 1.25rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.ledger-transactions thead th {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.ledger-transactions tbody tr:hover {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.ledger-transactions tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.ledger-amount-heading,
+.ledger-amount {
+    text-align: right;
+}
+
+.ledger-amount {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+.ledger-cell-empty {
+    opacity: 0.55;
+    font-style: italic;
+}
+
+.ledger-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.ledger-pagination-count {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.ledger-pagination-controls {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.ledger-pagination-button {
+    border-radius: 0.5rem;
+    border: 1px solid rgba(56, 189, 248, 0.6);
+    padding: 0.5rem 1.25rem;
+    font-weight: 600;
+    text-decoration: none;
+    color: #38bdf8;
+    background: rgba(56, 189, 248, 0.08);
+    transition: background 150ms ease, border-color 150ms ease;
+}
+
+.ledger-pagination-button:hover {
+    background: rgba(56, 189, 248, 0.18);
+    border-color: rgba(56, 189, 248, 0.9);
+}
+
+.ledger-pagination-button.is-disabled {
+    opacity: 0.45;
+    pointer-events: none;
+}
+
+.ledger-empty {
+    border: 1px dashed rgba(148, 163, 184, 0.4);
+    border-radius: 0.75rem;
+    padding: 2.5rem 2rem;
+    text-align: center;
+    display: grid;
+    gap: 0.75rem;
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.ledger-empty h2 {
+    margin: 0;
+}
+
+.ledger-empty p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+@media (max-width: 720px) {
+    .ledger-summary {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    }
+
+    .ledger-transactions {
+        min-width: 100%;
+    }
+
+    .ledger-transactions thead {
+        display: none;
+    }
+
+    .ledger-transactions tbody tr {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.5rem 1rem;
+        padding: 1rem 0;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .ledger-transactions td {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        padding: 0;
+        border: none;
+    }
+
+    .ledger-transactions td::before {
+        content: attr(data-label);
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.65);
+        margin-right: 1rem;
+    }
+
+    .ledger-transactions td.ledger-amount {
+        justify-content: flex-end;
+    }
+}
+
 /* TODO(@ux-team): extend design tokens, typography scale, and dark/light mode palettes. */

--- a/pocketsage/templates/ledger/index.html
+++ b/pocketsage/templates/ledger/index.html
@@ -1,6 +1,111 @@
 {% extends 'base.html' %}
 {% block title %}Ledger · PocketSage{% endblock %}
+
+{% macro pagination_controls(pagination, prev_url, next_url) %}
+  {% if pagination.total > 0 %}
+    <div class="ledger-pagination" aria-label="Pagination controls">
+      <p class="ledger-pagination-count">
+        Showing {{ pagination.first_item }}–{{ pagination.last_item }} of {{ pagination.total }} transactions
+      </p>
+      <div class="ledger-pagination-controls">
+        <a
+          class="ledger-pagination-button{% if not prev_url %} is-disabled{% endif %}"
+          {% if prev_url %}href="{{ prev_url }}" rel="prev"{% else %}aria-disabled="true" tabindex="-1"{% endif %}
+        >
+          Previous
+        </a>
+        <a
+          class="ledger-pagination-button{% if not next_url %} is-disabled{% endif %}"
+          {% if next_url %}href="{{ next_url }}" rel="next"{% else %}aria-disabled="true" tabindex="-1"{% endif %}
+        >
+          Next
+        </a>
+      </div>
+    </div>
+  {% endif %}
+{% endmacro %}
+
 {% block content %}
-  <h1>Ledger</h1>
-  <p class="todo">TODO(@ledger-squad): render transaction table, filters, and rollups.</p>
+  <section class="ledger-header">
+    <div class="ledger-heading">
+      <h1>Ledger</h1>
+      <p class="ledger-subtitle">Track inflows and outflows across your accounts.</p>
+    </div>
+    <dl class="ledger-summary" aria-label="Ledger summary">
+      <div class="ledger-summary-card ledger-summary-card--inflow">
+        <dt>Inflow</dt>
+        <dd>{{ '${:,.2f}'.format(summary.inflow) }}</dd>
+      </div>
+      <div class="ledger-summary-card ledger-summary-card--outflow">
+        <dt>Outflow</dt>
+        <dd>{{ '${:,.2f}'.format(summary.outflow) }}</dd>
+      </div>
+      <div class="ledger-summary-card ledger-summary-card--net">
+        <dt>Net</dt>
+        <dd>{{ '${:,.2f}'.format(summary.net) }}</dd>
+      </div>
+    </dl>
+  </section>
+
+  <section class="ledger-table" aria-label="Ledger transactions">
+    {% if transactions %}
+      {{ pagination_controls(pagination, prev_url, next_url) }}
+      <div class="ledger-table-wrapper">
+        <table class="ledger-transactions">
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Memo</th>
+              <th scope="col">Account</th>
+              <th scope="col">Category</th>
+              <th scope="col" class="ledger-amount-heading">Amount</th>
+              <th scope="col">Currency</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for txn in transactions %}
+              {% set amount_class = 'ledger-amount ledger-amount--inflow' if txn.amount >= 0 else 'ledger-amount ledger-amount--outflow' %}
+              <tr>
+                <td data-label="Date">
+                  <time datetime="{{ txn.occurred_at.isoformat() }}">{{ txn.occurred_at.strftime('%b %d, %Y') }}</time>
+                </td>
+                <td data-label="Memo">
+                  {% if txn.memo %}
+                    {{ txn.memo }}
+                  {% else %}
+                    <span class="ledger-cell-empty">—</span>
+                  {% endif %}
+                </td>
+                <td data-label="Account">
+                  {% if txn.account_name %}
+                    {{ txn.account_name }}
+                  {% else %}
+                    <span class="ledger-cell-empty">—</span>
+                  {% endif %}
+                </td>
+                <td data-label="Category">
+                  {% if txn.category_name %}
+                    {{ txn.category_name }}
+                  {% else %}
+                    <span class="ledger-cell-empty">—</span>
+                  {% endif %}
+                </td>
+                <td class="{{ amount_class }}" data-label="Amount">
+                  {{ '${:,.2f}'.format(txn.amount) }}
+                </td>
+                <td data-label="Currency">{{ txn.currency }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {{ pagination_controls(pagination, prev_url, next_url) }}
+    {% else %}
+      <div class="ledger-empty">
+        <h2>No transactions yet</h2>
+        <p>Once you add or import transactions, cashflow activity will appear here.</p>
+        <a href="{{ url_for('ledger.new_transaction') }}" class="btn-secondary">Add a transaction</a>
+      </div>
+    {% endif %}
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a SQLModel-backed ledger repository that returns paginated rows with cashflow summary data
- update the ledger list route to pull transactions, pagination links, and summary context from the repository
- replace the ledger index template and styling with a responsive table, empty state, and inflow/outflow highlighting

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68f862e366d08321a1315f67c6861500