### PR TITLE
Add skip link and footer structure to base template

### DIFF
--- a/pocketsage/static/css/main.css
+++ b/pocketsage/static/css/main.css
@@ -9,6 +9,28 @@ body {
     color: var(--text, #f5f5f5);
 }
 
+.skip-link {
+    position: absolute;
+    left: 1rem;
+    top: 1rem;
+    transform: translateY(-150%);
+    padding: 0.75rem 1rem;
+    background: #0f172a;
+    color: #f8fafc;
+    border-radius: 0.5rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease-in-out;
+    z-index: 1000;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+    transform: translateY(0);
+    outline: 2px solid #38bdf8;
+    outline-offset: 4px;
+}
+
 .top-nav {
     background: #1f1f1f;
     padding: 0.75rem 1.5rem;
@@ -30,6 +52,24 @@ body {
 
 .container {
     padding: 2rem;
+}
+
+.site-footer {
+    margin-top: 3rem;
+    padding: 2rem;
+    background: rgba(15, 23, 42, 0.85);
+    color: #e2e8f0;
+    text-align: center;
+}
+
+.site-footer a {
+    color: #38bdf8;
+    text-decoration: none;
+}
+
+.site-footer a:focus,
+.site-footer a:hover {
+    text-decoration: underline;
 }
 
 .flash-messages {

--- a/pocketsage/templates/base.html
+++ b/pocketsage/templates/base.html
@@ -11,7 +11,7 @@
     <a class="skip-link" href="#main-content">Skip to main content</a>
     {% include '_nav.html' %}
     {% block breadcrumb %}{% endblock %}
-    <main id="main-content" class="container">
+    <main id="main-content" class="container" tabindex="-1">
       {% include '_flash.html' %}
       {% block content %}{% endblock %}
     </main>

--- a/pocketsage/templates/base.html
+++ b/pocketsage/templates/base.html
@@ -8,12 +8,19 @@
     {% block head %}{% endblock %}
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     {% include '_nav.html' %}
-    <main class="container">
+    {% block breadcrumb %}{% endblock %}
+    <main id="main-content" class="container">
       {% include '_flash.html' %}
       {% block content %}{% endblock %}
     </main>
     <script src="{{ url_for('static', filename='js/main.js') }}" defer></script>
     {% block scripts %}{% endblock %}
+    <footer class="site-footer">
+      {% block footer %}
+        <p>© PocketSage. Crafted with care.</p>
+      {% endblock %}
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add an accessible skip link, breadcrumb block, and footer block to the base template
- style the new skip link and footer with high-contrast, focus-visible states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f862e5b9788321bd322423cb627b1e